### PR TITLE
feat(collections): add GSMG puzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ boha list b1000 --with-pubkey
 
 # Show puzzle details
 boha show b1000/66
+boha show gsmg
 boha show hash_collision/sha256
 
 # Get key range
@@ -76,7 +77,7 @@ boha -o jsonl list b1000 --unsolved | jq .
 ### Library
 
 ```rust
-use boha::{b1000, hash_collision, Status};
+use boha::{b1000, gsmg, hash_collision, Status};
 
 let p66 = b1000::get(66).unwrap();
 println!("Address: {}", p66.address);
@@ -90,9 +91,11 @@ let unsolved: Vec<_> = b1000::all()
     .filter(|p| p.pubkey.is_some())
     .collect();
 
+let gsmg_puzzle = gsmg::get();
 let sha256 = hash_collision::get("sha256").unwrap();
 
 let puzzle = boha::get("b1000/66").unwrap();
+let puzzle = boha::get("gsmg").unwrap();
 ```
 
 ### Balance fetching (async)
@@ -130,6 +133,16 @@ async fn main() {
 **Unsolved (72):** 71-74, 76-79, 81-84, 86-89, 91-94, 96-99, 101-104, 106-109, 111-114, 116-119, 121-124, 126-129, 131-134, 136-139, 141-144, 146-149, 151-154, 156-159
 
 **Empty - no funds (96):** 161-256
+
+### gsmg
+
+[GSMG.IO 5 BTC Puzzle](https://gsmg.io/puzzle) - Multi-phase cryptographic challenge with a single Bitcoin address.
+
+| Address | Status | Prize |
+|---------|--------|-------|
+| 1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe | Unsolved | ~1.25 BTC |
+
+Originally 5 BTC, prize halves with each Bitcoin halving.
 
 ### hash_collision
 

--- a/data/gsmg.toml
+++ b/data/gsmg.toml
@@ -1,0 +1,11 @@
+# GSMG.IO 5 BTC Puzzle
+# Multi-phase cryptographic challenge with single Bitcoin address
+
+[metadata]
+source_url = "https://gsmg.io/puzzle"
+
+[puzzle]
+address = "1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe"
+status = "unsolved"
+btc = 1.25364181
+start_date = "2019-04-13"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use boha::{b1000, hash_collision, Puzzle, Stats, Status};
+use boha::{b1000, gsmg, hash_collision, Puzzle, Stats, Status};
 use clap::{Parser, Subcommand, ValueEnum};
 use owo_colors::OwoColorize;
 use serde::Serialize;
@@ -442,6 +442,7 @@ fn cmd_list(
 ) {
     let puzzles: Vec<&Puzzle> = match collection {
         "b1000" => b1000::all().collect(),
+        "gsmg" => gsmg::all().collect(),
         "hash_collision" | "peter_todd" => hash_collision::all().collect(),
         _ => boha::all().collect(),
     };

--- a/src/collections/gsmg.rs
+++ b/src/collections/gsmg.rs
@@ -1,0 +1,15 @@
+use crate::{AddressType, Puzzle, Status};
+
+include!(concat!(env!("OUT_DIR"), "/gsmg_data.rs"));
+
+pub fn get() -> &'static Puzzle {
+    &PUZZLE
+}
+
+pub fn all() -> impl Iterator<Item = &'static Puzzle> {
+    std::iter::once(&PUZZLE)
+}
+
+pub const fn count() -> usize {
+    1
+}

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,2 +1,3 @@
 pub mod b1000;
+pub mod gsmg;
 pub mod hash_collision;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod puzzle;
 #[cfg(feature = "balance")]
 pub mod balance;
 
-pub use collections::{b1000, hash_collision};
+pub use collections::{b1000, gsmg, hash_collision};
 pub use puzzle::{AddressType, IntoPuzzleNum, Puzzle, Status};
 
 use thiserror::Error;
@@ -22,6 +22,10 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub fn get(id: &str) -> Result<&'static Puzzle> {
+    if id == "gsmg" {
+        return Ok(gsmg::get());
+    }
+
     let parts: Vec<&str> = id.split('/').collect();
     if parts.len() < 2 {
         return Err(Error::NotFound(id.to_string()));
@@ -40,7 +44,7 @@ pub fn get(id: &str) -> Result<&'static Puzzle> {
 }
 
 pub fn all() -> impl Iterator<Item = &'static Puzzle> {
-    b1000::all().chain(hash_collision::all())
+    b1000::all().chain(gsmg::all()).chain(hash_collision::all())
 }
 
 #[derive(Debug, Default, Clone, serde::Serialize)]

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,4 +1,4 @@
-use boha::{b1000, hash_collision, AddressType, Status};
+use boha::{b1000, gsmg, hash_collision, AddressType, Status};
 
 #[test]
 fn b1000_has_256_puzzles() {
@@ -111,8 +111,23 @@ fn hash_collision_all_p2sh() {
 }
 
 #[test]
+fn gsmg_count() {
+    assert_eq!(gsmg::all().count(), 1);
+}
+
+#[test]
+fn gsmg_get_returns_correct_puzzle() {
+    let puzzle = gsmg::get();
+    assert_eq!(puzzle.id, "gsmg");
+    assert_eq!(puzzle.address, "1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe");
+    assert_eq!(puzzle.status, Status::Unsolved);
+    assert_eq!(puzzle.address_type, AddressType::P2PKH);
+}
+
+#[test]
 fn universal_get_works() {
     assert!(boha::get("b1000/66").is_ok());
+    assert!(boha::get("gsmg").is_ok());
     assert!(boha::get("hash_collision/sha256").is_ok());
     assert!(boha::get("peter_todd/sha256").is_ok());
 }


### PR DESCRIPTION
## Summary

Add GSMG.IO 5 BTC cryptographic puzzle as a new collection.

This puzzle features a single Bitcoin address with a multi-phase cryptographic challenge. The prize originally was 5 BTC but halves with each Bitcoin halving (currently ~1.25 BTC).

Closes #2

## Changes

- Create `data/gsmg.toml` with puzzle data (address, status, BTC, dates)
- Add build-time codegen for single-puzzle collection pattern
- Implement `gsmg` module with simplified API (`gsmg::get()` without parameters)
- Support `boha::get("gsmg")` without slash identifier
- Add CLI support for `list gsmg` and `show gsmg`
- Add validation tests for GSMG collection
- Update README with GSMG documentation

## API

```rust
gsmg::get()           // -> &'static Puzzle (infallible)
boha::get("gsmg")     // -> Result<&'static Puzzle>
```

## Testing

- `cargo test` - 18 tests pass (2 new for GSMG)
- `cargo clippy` - no warnings
- CLI verified: `boha show gsmg`, `boha list gsmg`

---
Co-Authored-By: Aei <aei@oad.earth>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GSMG.IO 5 BTC puzzle as a new single-puzzle collection with simple library and CLI access. Fulfills #2 by enabling boha::get("gsmg") and documenting the puzzle.

- **New Features**
  - New gsmg collection generated at build-time from data/gsmg.toml
  - Library: gsmg::get(), boha::get("gsmg"), boha::all() now includes gsmg
  - CLI: support for list gsmg and show gsmg
  - README updated with GSMG details
  - Validation tests for gsmg count and puzzle fields

<sup>Written for commit e74c0617d2aeaeff533522c61773ab60e7456dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

