### PR TITLE
feat(puzzle): add claim_txid accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ println!("Funded: {}", p66.start_date.unwrap_or("unknown"));
 let range = p66.key_range().unwrap();
 println!("Range: 0x{:x} - 0x{:x}", range.start(), range.end());
 
+if let Some(txid) = p66.claim_txid() {
+    println!("Claimed in: {}", txid);
+    println!("Explorer: {}", p66.chain.tx_explorer_url(txid));
+}
+
 let unsolved: Vec<_> = b1000::all()
     .filter(|p| p.status == Status::Unsolved)
     .filter(|p| p.pubkey.is_some())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -474,6 +474,17 @@ fn print_puzzle_detail_table(p: &Puzzle, show_transactions: bool) {
         });
     }
 
+    if let Some(txid) = p.claim_txid() {
+        rows.push(KeyValueRow {
+            field: "Claim TX".to_string(),
+            value: txid.to_string(),
+        });
+        rows.push(KeyValueRow {
+            field: "Claim TX URL".to_string(),
+            value: p.chain.tx_explorer_url(txid),
+        });
+    }
+
     if let Some(url) = p.source_url {
         rows.push(KeyValueRow {
             field: "Source".to_string(),

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -38,6 +38,16 @@ impl Chain {
             Chain::Decred => "Decred",
         }
     }
+
+    pub fn tx_explorer_url(&self, txid: &str) -> String {
+        match self {
+            Chain::Bitcoin => format!("https://mempool.space/tx/{}", txid),
+            Chain::Ethereum => format!("https://etherscan.io/tx/{}", txid),
+            Chain::Litecoin => format!("https://blockchair.com/litecoin/transaction/{}", txid),
+            Chain::Monero => format!("https://xmrchain.net/tx/{}", txid),
+            Chain::Decred => format!("https://dcrdata.decred.org/tx/{}", txid),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -241,6 +251,14 @@ impl Puzzle {
         self.transactions
             .iter()
             .find(|t| t.tx_type == TransactionType::Claim)
+    }
+
+    pub fn claim_txid(&self) -> Option<&'static str> {
+        self.claim_tx().and_then(|tx| tx.txid)
+    }
+
+    pub fn funding_txid(&self) -> Option<&'static str> {
+        self.funding_tx().and_then(|tx| tx.txid)
     }
 
     pub fn has_transactions(&self) -> bool {

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -854,3 +854,56 @@ fn transactions_chronologically_ordered() {
         }
     }
 }
+
+#[test]
+fn claim_txid_matches_claim_tx() {
+    for puzzle in b1000::solved() {
+        let txid = puzzle.claim_txid();
+        let from_tx = puzzle.claim_tx().and_then(|t| t.txid);
+        assert_eq!(txid, from_tx, "claim_txid() mismatch for {}", puzzle.id);
+    }
+}
+
+#[test]
+fn funding_txid_matches_funding_tx() {
+    for puzzle in boha::all() {
+        let txid = puzzle.funding_txid();
+        let from_tx = puzzle.funding_tx().and_then(|t| t.txid);
+        assert_eq!(txid, from_tx, "funding_txid() mismatch for {}", puzzle.id);
+    }
+}
+
+#[test]
+fn unsolved_puzzles_no_claim_txid() {
+    for puzzle in b1000::unsolved() {
+        assert!(
+            puzzle.claim_txid().is_none(),
+            "Unsolved puzzle {} should not have claim_txid",
+            puzzle.id
+        );
+    }
+}
+
+#[test]
+fn tx_explorer_url_format() {
+    assert_eq!(
+        Chain::Bitcoin.tx_explorer_url("abc123"),
+        "https://mempool.space/tx/abc123"
+    );
+    assert_eq!(
+        Chain::Ethereum.tx_explorer_url("0xdef456"),
+        "https://etherscan.io/tx/0xdef456"
+    );
+    assert_eq!(
+        Chain::Litecoin.tx_explorer_url("abc"),
+        "https://blockchair.com/litecoin/transaction/abc"
+    );
+    assert_eq!(
+        Chain::Monero.tx_explorer_url("xyz"),
+        "https://xmrchain.net/tx/xyz"
+    );
+    assert_eq!(
+        Chain::Decred.tx_explorer_url("dcr123"),
+        "https://dcrdata.decred.org/tx/dcr123"
+    );
+}


### PR DESCRIPTION
## Summary

Add convenient accessors for claim/funding transaction IDs and block explorer URLs, improving ergonomics for library users and CLI UX.

The underlying transaction data already existed via the `transactions` array - this adds direct access patterns.

Closes #38

## Changes

- Add `puzzle.claim_txid()` getter - returns claim transaction ID directly
- Add `puzzle.funding_txid()` getter - returns funding transaction ID directly  
- Add `chain.tx_explorer_url(txid)` - generates block explorer URL for any chain
- CLI `show` now displays "Claim TX" and "Claim TX URL" for solved puzzles by default
- Add 4 new validation tests
- Update README with usage examples

## Testing

- `just test` - 63 validation tests pass (4 new)
- `just clippy` - no warnings
- Manual CLI verification for solved/unsolved puzzles

---
Co-Authored-By: Aei <aei@oad.earth>