### PR TITLE
feat(address): add Address struct

### DIFF
--- a/data/b1000.toml
+++ b/data/b1000.toml
@@ -19,7 +19,7 @@ with_pubkey_count = 184
 # The trivial private key (1) was discovered and claimed in 2013, before the puzzle existed.
 [[puzzles]]
 bits = 1
-address = "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH"
+address = { value = "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH", kind = "p2pkh", hash160 = "751e76e8199196d454941c45d1b3a323f1433bd6" }
 prize = 0.001
 status = "solved"
 has_pubkey = true
@@ -28,7 +28,6 @@ public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 pubkey_format = "compressed"
 solve_date = "2025-11-02 04:30:06"
 start_date = "2023-08-20 18:39:19"
-h160 = "751e76e8199196d454941c45d1b3a323f1433bd6"
 solve_time = 69501047
 pre_genesis = true
 transactions = [{ type = "funding", txid = "9223da07e858c6f153fbb8a24db52374ca19d2639098207c71710610cfda808e", date = "2013-01-09 11:59:15", amount = 0.03 }, { type = "claim", txid = "3da9b8e4a9c056b22d4fd09784402fd1caab1ecf621ba074efc20dc03ff04277", date = "2013-01-10 02:54:44", amount = 0.03 }]
@@ -36,7 +35,7 @@ transactions = [{ type = "funding", txid = "9223da07e858c6f153fbb8a24db52374ca19
 # Note: Puzzle 2 has a test transaction from the author predating puzzle creation (2015-01-15).
 [[puzzles]]
 bits = 2
-address = "1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb"
+address = { value = "1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb", kind = "p2pkh", hash160 = "7dd65592d0ab2fe0d0257d571abf032cd9db93dc" }
 prize = 0.002
 status = "solved"
 has_pubkey = true
@@ -45,14 +44,13 @@ public_key = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9
 pubkey_format = "compressed"
 solve_date = "2024-07-14 20:04:27"
 start_date = "2014-07-29 21:53:54"
-h160 = "7dd65592d0ab2fe0d0257d571abf032cd9db93dc"
 solve_time = 314316633
 pre_genesis = true
 transactions = [{ type = "funding", txid = "9294c9d71d9da40bc4344b5755e7652789df3bc1a9f660e040725216361d1c54", date = "2014-07-29 21:53:54", amount = 0.0001 }, { type = "pubkey_reveal", txid = "30ab16d9eb2777caa6d4734d620d618fc797f62b3f7a167b97b0edc0e0cf8973", date = "2014-07-29 21:53:54", amount = 0.0001 }, { type = "increase", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.002 }, { type = "claim", txid = "4feb64593f6bd3ebc05906db6aeb7f6c9beb65a970d97b48c64fb4653774d79e", date = "2015-01-15 18:07:14", amount = 0.002 }]
 
 [[puzzles]]
 bits = 3
-address = "19ZewH8Kk1PDbSNdJ97FP4EiCjTRaZMZQA"
+address = { value = "19ZewH8Kk1PDbSNdJ97FP4EiCjTRaZMZQA", kind = "p2pkh", hash160 = "5dedfbf9ea599dd4e3ca6a80b333c472fd0b3f69" }
 prize = 0.003
 status = "solved"
 has_pubkey = true
@@ -61,13 +59,12 @@ public_key = "025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc
 pubkey_format = "compressed"
 solve_date = "2020-05-30 08:28:13"
 start_date = "2015-01-15 18:07:14"
-h160 = "5dedfbf9ea599dd4e3ca6a80b333c472fd0b3f69"
 solve_time = 169482059
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.003 }, { type = "claim", txid = "fa1b9a669a7c16f1d0b15cfb57e9830ccee36db984bd074de450e47088c8d078", date = "2015-01-15 18:07:14", amount = 0.003 }]
 
 [[puzzles]]
 bits = 4
-address = "1EhqbyUMvvs7BfL8goY6qcPbD6YKfPqb7e"
+address = { value = "1EhqbyUMvvs7BfL8goY6qcPbD6YKfPqb7e", kind = "p2pkh", hash160 = "9652d86bedf43ad264362e6e6eba6eb764508127" }
 prize = 0.004
 status = "solved"
 has_pubkey = true
@@ -76,13 +73,12 @@ public_key = "022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01
 pubkey_format = "compressed"
 solve_date = "2021-03-29 06:42:00"
 start_date = "2015-01-15 18:07:14"
-h160 = "9652d86bedf43ad264362e6e6eba6eb764508127"
 solve_time = 195654886
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.004 }, { type = "claim", txid = "7c4f3c3022a956e7ad80bd0d3642f7e2e0a3dd4b275b7241cf1963610250d65b", date = "2015-01-15 18:07:14", amount = 0.004 }]
 
 [[puzzles]]
 bits = 5
-address = "1E6NuFjCi27W5zoXg8TRdcSRq84zJeBW3k"
+address = { value = "1E6NuFjCi27W5zoXg8TRdcSRq84zJeBW3k", kind = "p2pkh", hash160 = "8f9dff39a81ee4abcbad2ad8bafff090415a2be8" }
 prize = 0.005
 status = "solved"
 has_pubkey = true
@@ -91,13 +87,12 @@ public_key = "02352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "8f9dff39a81ee4abcbad2ad8bafff090415a2be8"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.005 }, { type = "claim", txid = "4f5a32521f352d48cc4491c6de3485764997c0cd089f63e822f4e7ed05015d20", date = "2015-01-15 18:07:14", amount = 0.005 }]
 
 [[puzzles]]
 bits = 6
-address = "1PitScNLyp2HCygzadCh7FveTnfmpPbfp8"
+address = { value = "1PitScNLyp2HCygzadCh7FveTnfmpPbfp8", kind = "p2pkh", hash160 = "f93ec34e9e34a8f8ff7d600cdad83047b1bcb45c" }
 prize = 0.006
 status = "solved"
 has_pubkey = true
@@ -106,13 +101,12 @@ public_key = "03f2dac991cc4ce4b9ea44887e5c7c0bce58c80074ab9d4dbaeb28531b7739f530
 pubkey_format = "compressed"
 solve_date = "2020-10-14 16:26:44"
 start_date = "2015-01-15 18:07:14"
-h160 = "f93ec34e9e34a8f8ff7d600cdad83047b1bcb45c"
 solve_time = 181347570
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.006 }, { type = "claim", txid = "aa75e831a27d71dae09a5feeb7fec041ba0a55d1e9c3ac1d32ce88852dcedaa3", date = "2015-01-15 18:07:14", amount = 0.006 }]
 
 [[puzzles]]
 bits = 7
-address = "1McVt1vMtCC7yn5b9wgX1833yCcLXzueeC"
+address = { value = "1McVt1vMtCC7yn5b9wgX1833yCcLXzueeC", kind = "p2pkh", hash160 = "e2192e8a7dd8dd1c88321959b477968b941aa973" }
 prize = 0.007
 status = "solved"
 has_pubkey = true
@@ -121,13 +115,12 @@ public_key = "0296516a8f65774275278d0d7420a88df0ac44bd64c7bae07c3fe397c5b3300b23
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "e2192e8a7dd8dd1c88321959b477968b941aa973"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.007 }, { type = "claim", txid = "09817b72199818d5610d44f9427f87c84ef3905004b751c5198059188e2de9b4", date = "2015-01-15 18:07:14", amount = 0.007 }]
 
 [[puzzles]]
 bits = 8
-address = "1M92tSqNmQLYw33fuBvjmeadirh1ysMBxK"
+address = { value = "1M92tSqNmQLYw33fuBvjmeadirh1ysMBxK", kind = "p2pkh", hash160 = "dce76b2613052ea012204404a97b3c25eac31715" }
 prize = 0.008
 status = "solved"
 has_pubkey = true
@@ -136,13 +129,12 @@ public_key = "0308bc89c2f919ed158885c35600844d49890905c79b357322609c45706ce6b514
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "dce76b2613052ea012204404a97b3c25eac31715"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.008 }, { type = "claim", txid = "0827fb603364998f7f24724e2f4f4befd6ada60dbef28f91307fe7a79e98a4f8", date = "2015-01-15 18:07:14", amount = 0.008 }]
 
 [[puzzles]]
 bits = 9
-address = "1CQFwcjw1dwhtkVWBttNLDtqL7ivBonGPV"
+address = { value = "1CQFwcjw1dwhtkVWBttNLDtqL7ivBonGPV", kind = "p2pkh", hash160 = "7d0f6c64afb419bbd7e971e943d7404b0e0daab4" }
 prize = 0.009
 status = "solved"
 has_pubkey = true
@@ -151,13 +143,12 @@ public_key = "0243601d61c836387485e9514ab5c8924dd2cfd466af34ac95002727e1659d60f7
 pubkey_format = "compressed"
 solve_date = "2020-09-23 16:46:17"
 start_date = "2015-01-15 18:07:14"
-h160 = "7d0f6c64afb419bbd7e971e943d7404b0e0daab4"
 solve_time = 179534343
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.009 }, { type = "claim", txid = "49647889152f4f444e6007e94d59f24003e9f012687efbd7bc273c26371c3aba", date = "2015-01-15 18:07:14", amount = 0.009 }]
 
 [[puzzles]]
 bits = 10
-address = "1LeBZP5QCwwgXRtmVUvTVrraqPUokyLHqe"
+address = { value = "1LeBZP5QCwwgXRtmVUvTVrraqPUokyLHqe", kind = "p2pkh", hash160 = "d7729816650e581d7462d52ad6f732da0e2ec93b" }
 prize = 0.01
 status = "solved"
 has_pubkey = true
@@ -166,13 +157,12 @@ public_key = "03a7a4c30291ac1db24b4ab00c442aa832f7794b5a0959bec6e8d7fee802289dcd
 pubkey_format = "compressed"
 solve_date = "2020-07-08 15:43:11"
 start_date = "2015-01-15 18:07:14"
-h160 = "d7729816650e581d7462d52ad6f732da0e2ec93b"
 solve_time = 172877757
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.01 }, { type = "claim", txid = "b70f19f2581acf4320cf069379982f2df6f9c8b8ef91ed59279e32453a81ad62", date = "2015-01-15 18:07:14", amount = 0.01 }]
 
 [[puzzles]]
 bits = 11
-address = "1PgQVLmst3Z314JrQn5TNiys8Hc38TcXJu"
+address = { value = "1PgQVLmst3Z314JrQn5TNiys8Hc38TcXJu", kind = "p2pkh", hash160 = "f8c698da3164ef8fa4258692d118cc9a902c5acc" }
 prize = 0.011
 status = "solved"
 has_pubkey = true
@@ -181,13 +171,12 @@ public_key = "038b05b0603abd75b0c57489e451f811e1afe54a8715045cdf4888333f3ebc6e8b
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "f8c698da3164ef8fa4258692d118cc9a902c5acc"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.011 }, { type = "claim", txid = "5c2f4fc31a359f72a363488496365eff2e8eed1b59e4e6dc240d5b8dfa740376", date = "2015-01-15 18:07:14", amount = 0.011 }]
 
 [[puzzles]]
 bits = 12
-address = "1DBaumZxUkM4qMQRt2LVWyFJq5kDtSZQot"
+address = { value = "1DBaumZxUkM4qMQRt2LVWyFJq5kDtSZQot", kind = "p2pkh", hash160 = "85a1f9ba4da24c24e582d9b891dacbd1b043f971" }
 prize = 0.012
 status = "solved"
 has_pubkey = true
@@ -196,13 +185,12 @@ public_key = "038b00fcbfc1a203f44bf123fc7f4c91c10a85c8eae9187f9d22242b4600ce781c
 pubkey_format = "compressed"
 solve_date = "2019-09-07 10:42:47"
 start_date = "2015-01-15 18:07:14"
-h160 = "85a1f9ba4da24c24e582d9b891dacbd1b043f971"
 solve_time = 146507733
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.012 }, { type = "claim", txid = "5bf0a6d4af73ac148a5b1d26c82d4c7567f45f868f427b48efad7cae08fb22df", date = "2015-01-15 18:07:14", amount = 0.012 }]
 
 [[puzzles]]
 bits = 13
-address = "1Pie8JkxBT6MGPz9Nvi3fsPkr2D8q3GBc1"
+address = { value = "1Pie8JkxBT6MGPz9Nvi3fsPkr2D8q3GBc1", kind = "p2pkh", hash160 = "f932d0188616c964416b91fb9cf76ba9790a921e" }
 prize = 0.013
 status = "solved"
 has_pubkey = true
@@ -211,13 +199,12 @@ public_key = "03aadaaab1db8d5d450b511789c37e7cfeb0eb8b3e61a57a34166c5edc9a4b869d
 pubkey_format = "compressed"
 solve_date = "2025-09-23 03:31:11"
 start_date = "2015-01-15 18:07:14"
-h160 = "f932d0188616c964416b91fb9cf76ba9790a921e"
 solve_time = 337253037
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.013 }, { type = "claim", txid = "2686aca4a211031b75396dbb9baecadfc01a1534d8682c8eacd307ab2c8f47e0", date = "2015-01-15 18:07:14", amount = 0.013 }]
 
 [[puzzles]]
 bits = 14
-address = "1ErZWg5cFCe4Vw5BzgfzB74VNLaXEiEkhk"
+address = { value = "1ErZWg5cFCe4Vw5BzgfzB74VNLaXEiEkhk", kind = "p2pkh", hash160 = "97f9281a1383879d72ac52a6a3e9e8b9a4a4f655" }
 prize = 0.014
 status = "solved"
 has_pubkey = true
@@ -226,13 +213,12 @@ public_key = "03b4f1de58b8b41afe9fd4e5ffbdafaeab86c5db4769c15d6e6011ae7351e54759
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "97f9281a1383879d72ac52a6a3e9e8b9a4a4f655"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.014 }, { type = "claim", txid = "c0d88c38111f54c86e2f5f1921c8dedd6b8ca6052baf496010ab755dcece5b46", date = "2015-01-15 18:07:14", amount = 0.014 }]
 
 [[puzzles]]
 bits = 15
-address = "1QCbW9HWnwQWiQqVo5exhAnmfqKRrCRsvW"
+address = { value = "1QCbW9HWnwQWiQqVo5exhAnmfqKRrCRsvW", kind = "p2pkh", hash160 = "fe7c45126731f7384640b0b0045fd40bac72e2a2" }
 prize = 0.015
 status = "solved"
 has_pubkey = true
@@ -241,13 +227,12 @@ public_key = "02fea58ffcf49566f6e9e9350cf5bca2861312f422966e8db16094beb14dc3df2c
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "fe7c45126731f7384640b0b0045fd40bac72e2a2"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.015 }, { type = "claim", txid = "b82f780d5619131a0f98eb0bcfc2f01ce4b3997bc0066d9498b22073c163f4cf", date = "2015-01-15 18:07:14", amount = 0.015 }]
 
 [[puzzles]]
 bits = 16
-address = "1BDyrQ6WoF8VN3g9SAS1iKZcPzFfnDVieY"
+address = { value = "1BDyrQ6WoF8VN3g9SAS1iKZcPzFfnDVieY", kind = "p2pkh", hash160 = "7025b4efb3ff42eb4d6d71fab6b53b4f4967e3dd" }
 prize = 0.016
 status = "solved"
 has_pubkey = true
@@ -256,13 +241,12 @@ public_key = "029d8c5d35231d75eb87fd2c5f05f65281ed9573dc41853288c62ee94eb2590b7a
 pubkey_format = "compressed"
 solve_date = "2019-09-07 17:20:13"
 start_date = "2015-01-15 18:07:14"
-h160 = "7025b4efb3ff42eb4d6d71fab6b53b4f4967e3dd"
 solve_time = 146531579
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.016 }, { type = "claim", txid = "4d102a549127e6fcdc4f6b4820a2c99eeba71af9fc0d6e79f43571f192bd09c8", date = "2015-01-15 18:07:14", amount = 0.016 }]
 
 [[puzzles]]
 bits = 17
-address = "1HduPEXZRdG26SUT5Yk83mLkPyjnZuJ7Bm"
+address = { value = "1HduPEXZRdG26SUT5Yk83mLkPyjnZuJ7Bm", kind = "p2pkh", hash160 = "b67cb6edeabc0c8b927c9ea327628e7aa63e2d52" }
 prize = 0.017
 status = "solved"
 has_pubkey = true
@@ -271,13 +255,12 @@ public_key = "033f688bae8321b8e02b7e6c0a55c2515fb25ab97d85fda842449f7bfa04e128c3
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "b67cb6edeabc0c8b927c9ea327628e7aa63e2d52"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.017 }, { type = "claim", txid = "e1818d951b51d4a0ed05f49b52e3300524bbdd03ad5d29bad15a1a09a5431e50", date = "2015-01-15 18:07:14", amount = 0.017 }]
 
 [[puzzles]]
 bits = 18
-address = "1GnNTmTVLZiqQfLbAdp9DVdicEnB5GoERE"
+address = { value = "1GnNTmTVLZiqQfLbAdp9DVdicEnB5GoERE", kind = "p2pkh", hash160 = "ad1e852b08eba53df306ec9daa8c643426953f94" }
 prize = 0.018
 status = "solved"
 has_pubkey = true
@@ -286,13 +269,12 @@ public_key = "020ce4a3291b19d2e1a7bf73ee87d30a6bdbc72b20771e7dfff40d0db755cd4af1
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "ad1e852b08eba53df306ec9daa8c643426953f94"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.018 }, { type = "claim", txid = "f785502a72d26cd6b6d26da5d5b4917f2fc5b74e57d7a139f4b7c2275acf2b62", date = "2015-01-15 18:07:14", amount = 0.018 }]
 
 [[puzzles]]
 bits = 19
-address = "1NWmZRpHH4XSPwsW6dsS3nrNWfL1yrJj4w"
+address = { value = "1NWmZRpHH4XSPwsW6dsS3nrNWfL1yrJj4w", kind = "p2pkh", hash160 = "ebfbe6819fcdebab061732ce91df7d586a037dee" }
 prize = 0.019
 status = "solved"
 has_pubkey = true
@@ -301,13 +283,12 @@ public_key = "0385663c8b2f90659e1ccab201694f4f8ec24b3749cfe5030c7c3646a709408e19
 pubkey_format = "compressed"
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
-h160 = "ebfbe6819fcdebab061732ce91df7d586a037dee"
 solve_time = 0
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.019 }, { type = "claim", txid = "ea746998394eafff179098d4df6a9c7caf79b2583a316ac0948276edfc58ba43", date = "2015-01-15 18:07:14", amount = 0.019 }]
 
 [[puzzles]]
 bits = 20
-address = "1HsMJxNiV7TLxmoF6uJNkydxPFDog4NQum"
+address = { value = "1HsMJxNiV7TLxmoF6uJNkydxPFDog4NQum", kind = "p2pkh", hash160 = "b907c3a2a3b27789dfb509b730dd47703c272868" }
 prize = 0.02
 status = "solved"
 has_pubkey = true
@@ -316,13 +297,12 @@ public_key = "033c4a45cbd643ff97d77f41ea37e843648d50fd894b864b0d52febc62f6454f7c
 pubkey_format = "compressed"
 solve_date = "2025-08-14 01:32:30"
 start_date = "2015-01-15 18:07:14"
-h160 = "b907c3a2a3b27789dfb509b730dd47703c272868"
 solve_time = 333789916
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.02 }, { type = "claim", txid = "3121aba5b7cc4d766a1e1b937c456d299bd75c6f3059c82353a4918b714d66c4", date = "2015-01-15 18:07:14", amount = 0.02 }]
 
 [[puzzles]]
 bits = 21
-address = "14oFNXucftsHiUMY8uctg6N487riuyXs4h"
+address = { value = "14oFNXucftsHiUMY8uctg6N487riuyXs4h", kind = "p2pkh", hash160 = "29a78213caa9eea824acf08022ab9dfc83414f56" }
 prize = 0.021
 status = "solved"
 has_pubkey = true
@@ -331,13 +311,12 @@ public_key = "031a746c78f72754e0be046186df8a20cdce5c79b2eda76013c647af08d306e49e
 pubkey_format = "compressed"
 solve_date = "2019-09-03 21:59:53"
 start_date = "2015-01-15 18:07:14"
-h160 = "29a78213caa9eea824acf08022ab9dfc83414f56"
 solve_time = 146202759
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.021 }, { type = "claim", txid = "cfbfafab6e04041ad36fb2395c2dd384f943ebdf61910c799f8f4a87276b2914", date = "2015-01-15 19:11:31", amount = 0.021 }]
 
 [[puzzles]]
 bits = 22
-address = "1CfZWK1QTQE3eS9qn61dQjV89KDjZzfNcv"
+address = { value = "1CfZWK1QTQE3eS9qn61dQjV89KDjZzfNcv", kind = "p2pkh", hash160 = "7ff45303774ef7a52fffd8011981034b258cb86b" }
 prize = 0.022
 status = "solved"
 has_pubkey = true
@@ -346,13 +325,12 @@ public_key = "023ed96b524db5ff4fe007ce730366052b7c511dc566227d929070b9ce917abb43
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "7ff45303774ef7a52fffd8011981034b258cb86b"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.022 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.022 }]
 
 [[puzzles]]
 bits = 23
-address = "1L2GM8eE7mJWLdo3HZS6su1832NX2txaac"
+address = { value = "1L2GM8eE7mJWLdo3HZS6su1832NX2txaac", kind = "p2pkh", hash160 = "d0a79df189fe1ad5c306cc70497b358415da579e" }
 prize = 0.023
 status = "solved"
 has_pubkey = true
@@ -361,13 +339,12 @@ public_key = "03f82710361b8b81bdedb16994f30c80db522450a93e8e87eeb07f7903cf28d04b
 pubkey_format = "compressed"
 solve_date = "2015-01-15 19:11:31"
 start_date = "2015-01-15 18:07:14"
-h160 = "d0a79df189fe1ad5c306cc70497b358415da579e"
 solve_time = 3857
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.023 }, { type = "claim", txid = "cfbfafab6e04041ad36fb2395c2dd384f943ebdf61910c799f8f4a87276b2914", date = "2015-01-15 19:11:31", amount = 0.023 }]
 
 [[puzzles]]
 bits = 24
-address = "1rSnXMr63jdCuegJFuidJqWxUPV7AtUf7"
+address = { value = "1rSnXMr63jdCuegJFuidJqWxUPV7AtUf7", kind = "p2pkh", hash160 = "0959e80121f36aea13b3bad361c15dac26189e2f" }
 prize = 0.024
 status = "solved"
 has_pubkey = true
@@ -376,13 +353,12 @@ public_key = "036ea839d22847ee1dce3bfc5b11f6cf785b0682db58c35b63d1342eb221c3490c
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "0959e80121f36aea13b3bad361c15dac26189e2f"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.024 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.024 }]
 
 [[puzzles]]
 bits = 25
-address = "15JhYXn6Mx3oF4Y7PcTAv2wVVAuCFFQNiP"
+address = { value = "15JhYXn6Mx3oF4Y7PcTAv2wVVAuCFFQNiP", kind = "p2pkh", hash160 = "2f396b29b27324300d0c59b17c3abc1835bd3dbb" }
 prize = 0.025
 status = "solved"
 has_pubkey = true
@@ -391,13 +367,12 @@ public_key = "03057fbea3a2623382628dde556b2a0698e32428d3cd225f3bd034dca82dd7455a
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "2f396b29b27324300d0c59b17c3abc1835bd3dbb"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.025 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.025 }]
 
 [[puzzles]]
 bits = 26
-address = "1JVnST957hGztonaWK6FougdtjxzHzRMMg"
+address = { value = "1JVnST957hGztonaWK6FougdtjxzHzRMMg", kind = "p2pkh", hash160 = "bfebb73562d4541b32a02ba664d140b5a574792f" }
 prize = 0.026
 status = "solved"
 has_pubkey = true
@@ -406,13 +381,12 @@ public_key = "024e4f50a2a3eccdb368988ae37cd4b611697b26b29696e42e06d71368b4f3840f
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "bfebb73562d4541b32a02ba664d140b5a574792f"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.026 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.026 }]
 
 [[puzzles]]
 bits = 27
-address = "128z5d7nN7PkCuX5qoA4Ys6pmxUYnEy86k"
+address = { value = "128z5d7nN7PkCuX5qoA4Ys6pmxUYnEy86k", kind = "p2pkh", hash160 = "0c7aaf6caa7e5424b63d317f0f8f1f9fa40d5560" }
 prize = 0.027
 status = "solved"
 has_pubkey = true
@@ -421,13 +395,12 @@ public_key = "031a864bae3922f351f1b57cfdd827c25b7e093cb9c88a72c1cd893d9f90f44ece
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "0c7aaf6caa7e5424b63d317f0f8f1f9fa40d5560"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.027 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.027 }]
 
 [[puzzles]]
 bits = 28
-address = "12jbtzBb54r97TCwW3G1gCFoumpckRAPdY"
+address = { value = "12jbtzBb54r97TCwW3G1gCFoumpckRAPdY", kind = "p2pkh", hash160 = "1306b9e4ff56513a476841bac7ba48d69516b1da" }
 prize = 0.028
 status = "solved"
 has_pubkey = true
@@ -436,13 +409,12 @@ public_key = "03e9e661838a96a65331637e2a3e948dc0756e5009e7cb5c36664d9b72dd18c0a7
 pubkey_format = "compressed"
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
-h160 = "1306b9e4ff56513a476841bac7ba48d69516b1da"
 solve_time = 14891
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.028 }, { type = "claim", txid = "0eb5b5c103e68eb0931430e7786cf1b6962f9eed5a2cb5271d4dd1699b77e86f", date = "2015-01-15 22:15:25", amount = 0.028 }]
 
 [[puzzles]]
 bits = 29
-address = "19EEC52krRUK1RkUAEZmQdjTyHT7Gp1TYT"
+address = { value = "19EEC52krRUK1RkUAEZmQdjTyHT7Gp1TYT", kind = "p2pkh", hash160 = "5a416cc9148f4a377b672c8ae5d3287adaafadec" }
 prize = 0.029
 status = "solved"
 has_pubkey = true
@@ -451,13 +423,12 @@ public_key = "026caad634382d34691e3bef43ed4a124d8909a8a3362f91f1d20abaaf7e917b36
 pubkey_format = "compressed"
 solve_date = "2015-01-16 02:46:38"
 start_date = "2015-01-15 18:07:14"
-h160 = "5a416cc9148f4a377b672c8ae5d3287adaafadec"
 solve_time = 31164
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.029 }, { type = "claim", txid = "c9878a6de4f0d482020411aa870eb3f6ca04b3dd1b2cf3ac5cf1ae265196e269", date = "2015-01-16 02:46:38", amount = 0.029 }]
 
 [[puzzles]]
 bits = 30
-address = "1LHtnpd8nU5VHEMkG2TMYYNUjjLc992bps"
+address = { value = "1LHtnpd8nU5VHEMkG2TMYYNUjjLc992bps", kind = "p2pkh", hash160 = "d39c4704664e1deb76c9331e637564c257d68a08" }
 prize = 0.03
 status = "solved"
 has_pubkey = true
@@ -466,13 +437,12 @@ public_key = "030d282cf2ff536d2c42f105d0b8588821a915dc3f9a05bd98bb23af67a2e92a5b
 pubkey_format = "compressed"
 solve_date = "2018-08-07 20:59:56"
 start_date = "2015-01-15 18:07:14"
-h160 = "d39c4704664e1deb76c9331e637564c257d68a08"
 solve_time = 112330362
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.03 }, { type = "claim", txid = "7c08f94495f5773e65c50d7a0a03e366802de9ac4063ed79316d9eba332d0e9d", date = "2015-01-16 13:31:58", amount = 0.03 }]
 
 [[puzzles]]
 bits = 31
-address = "1LhE6sCTuGae42Axu1L1ZB7L96yi9irEBE"
+address = { value = "1LhE6sCTuGae42Axu1L1ZB7L96yi9irEBE", kind = "p2pkh", hash160 = "d805f6f251f7479ebd853b3d0f4b9b2656d92f1d" }
 prize = 0.031
 status = "solved"
 has_pubkey = true
@@ -481,13 +451,12 @@ public_key = "0387dc70db1806cd9a9a76637412ec11dd998be666584849b3185f7f9313c8fd28
 pubkey_format = "compressed"
 solve_date = "2015-01-16 08:02:15"
 start_date = "2015-01-15 18:07:14"
-h160 = "d805f6f251f7479ebd853b3d0f4b9b2656d92f1d"
 solve_time = 50101
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.031 }, { type = "claim", txid = "d482463d265ca83307f80ebcc2c3cb47b5b0e2347d08674ba0b7c2c6876155af", date = "2015-01-16 08:02:15", amount = 0.031 }]
 
 [[puzzles]]
 bits = 32
-address = "1FRoHA9xewq7DjrZ1psWJVeTer8gHRqEvR"
+address = { value = "1FRoHA9xewq7DjrZ1psWJVeTer8gHRqEvR", kind = "p2pkh", hash160 = "9e42601eeaedc244e15f17375adb0e2cd08efdc9" }
 prize = 0.032
 status = "solved"
 has_pubkey = true
@@ -496,13 +465,12 @@ public_key = "0209c58240e50e3ba3f833c82655e8725c037a2294e14cf5d73a5df8d56159de69
 pubkey_format = "compressed"
 solve_date = "2015-01-16 04:57:19"
 start_date = "2015-01-15 18:07:14"
-h160 = "9e42601eeaedc244e15f17375adb0e2cd08efdc9"
 solve_time = 39005
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.032 }, { type = "claim", txid = "919f5c226b8926d2203c6e1995738b7223b157740cb5c0fd33399860ded9866b", date = "2015-01-16 04:57:19", amount = 0.032 }]
 
 [[puzzles]]
 bits = 33
-address = "187swFMjz1G54ycVU56B7jZFHFTNVQFDiu"
+address = { value = "187swFMjz1G54ycVU56B7jZFHFTNVQFDiu", kind = "p2pkh", hash160 = "4e15e5189752d1eaf444dfd6bff399feb0443977" }
 prize = 0.033
 status = "solved"
 has_pubkey = true
@@ -511,13 +479,12 @@ public_key = "03a355aa5e2e09dd44bb46a4722e9336e9e3ee4ee4e7b7a0cf5785b283bf2ab579
 pubkey_format = "compressed"
 solve_date = "2015-01-16 16:43:28"
 start_date = "2015-01-15 18:07:14"
-h160 = "4e15e5189752d1eaf444dfd6bff399feb0443977"
 solve_time = 81374
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.033 }, { type = "claim", txid = "718f7962432312acda2aeecdf18e94f5960f51013cc4d38134e7493c21e77baf", date = "2015-01-16 16:43:28", amount = 0.033 }]
 
 [[puzzles]]
 bits = 34
-address = "1PWABE7oUahG2AFFQhhvViQovnCr4rEv7Q"
+address = { value = "1PWABE7oUahG2AFFQhhvViQovnCr4rEv7Q", kind = "p2pkh", hash160 = "f6d67d7983bf70450f295c9cb828daab265f1bfa" }
 prize = 0.034
 status = "solved"
 has_pubkey = true
@@ -526,13 +493,12 @@ public_key = "033cdd9d6d97cbfe7c26f902faf6a435780fe652e159ec953650ec7b1004082790
 pubkey_format = "compressed"
 solve_date = "2015-01-17 00:14:34"
 start_date = "2015-01-15 18:07:14"
-h160 = "f6d67d7983bf70450f295c9cb828daab265f1bfa"
 solve_time = 108440
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.034 }, { type = "claim", txid = "03da907c6b671764ee78fcca78e126c781640efb691d011f5aff0f09072a6104", date = "2015-01-17 00:14:34", amount = 0.034 }]
 
 [[puzzles]]
 bits = 35
-address = "1PWCx5fovoEaoBowAvF5k91m2Xat9bMgwb"
+address = { value = "1PWCx5fovoEaoBowAvF5k91m2Xat9bMgwb", kind = "p2pkh", hash160 = "f6d8ce225ffbdecec170f8298c3fc28ae686df25" }
 prize = 0.035
 status = "solved"
 has_pubkey = true
@@ -541,13 +507,12 @@ public_key = "02f6a8148a62320e149cb15c544fe8a25ab483a0095d2280d03b8a00a7feada13d
 pubkey_format = "compressed"
 solve_date = "2015-01-17 07:33:27"
 start_date = "2015-01-15 18:07:14"
-h160 = "f6d8ce225ffbdecec170f8298c3fc28ae686df25"
 solve_time = 134773
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.035 }, { type = "claim", txid = "9308722efdd45b5e4f6efbad73c9b0e5172bbc4db877a54d47b99caa31f08ab0", date = "2015-01-17 07:33:27", amount = 0.035 }]
 
 [[puzzles]]
 bits = 36
-address = "1Be2UF9NLfyLFbtm3TCbmuocc9N1Kduci1"
+address = { value = "1Be2UF9NLfyLFbtm3TCbmuocc9N1Kduci1", kind = "p2pkh", hash160 = "74b1e012be1521e5d8d75e745a26ced845ea3d37" }
 prize = 0.036
 status = "solved"
 has_pubkey = true
@@ -556,13 +521,12 @@ public_key = "02b3e772216695845fa9dda419fb5daca28154d8aa59ea302f05e916635e47b9f6
 pubkey_format = "compressed"
 solve_date = "2015-01-17 17:14:40"
 start_date = "2015-01-15 18:07:14"
-h160 = "74b1e012be1521e5d8d75e745a26ced845ea3d37"
 solve_time = 169646
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.036 }, { type = "claim", txid = "ef14a1ad1e267ffa71c2d6d719e094a444a0fce6658b47132df7b7c1d95b95b2", date = "2015-01-17 17:14:40", amount = 0.036 }]
 
 [[puzzles]]
 bits = 37
-address = "14iXhn8bGajVWegZHJ18vJLHhntcpL4dex"
+address = { value = "14iXhn8bGajVWegZHJ18vJLHhntcpL4dex", kind = "p2pkh", hash160 = "28c30fb9118ed1da72e7c4f89c0164756e8a021d" }
 prize = 0.037
 status = "solved"
 has_pubkey = true
@@ -571,13 +535,12 @@ public_key = "027d2c03c3ef0aec70f2c7e1e75454a5dfdd0e1adea670c1b3a4643c48ad0f1255
 pubkey_format = "compressed"
 solve_date = "2015-01-18 23:32:11"
 start_date = "2015-01-15 18:07:14"
-h160 = "28c30fb9118ed1da72e7c4f89c0164756e8a021d"
 solve_time = 278697
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.037 }, { type = "claim", txid = "21552e7e7e07498972ebf6e3ef56d7fc91dadbc7af32790e36ca2eeb4fd575c5", date = "2015-01-18 23:32:11", amount = 0.037 }]
 
 [[puzzles]]
 bits = 38
-address = "1HBtApAFA9B2YZw3G2YKSMCtb3dVnjuNe2"
+address = { value = "1HBtApAFA9B2YZw3G2YKSMCtb3dVnjuNe2", kind = "p2pkh", hash160 = "b190e2d40cfdeee2cee072954a2be89e7ba39364" }
 prize = 0.038
 status = "solved"
 has_pubkey = true
@@ -586,13 +549,12 @@ public_key = "03c060e1e3771cbeccb38e119c2414702f3f5181a89652538851d2e3886bdd70c6
 pubkey_format = "compressed"
 solve_date = "2015-01-19 10:27:27"
 start_date = "2015-01-15 18:07:14"
-h160 = "b190e2d40cfdeee2cee072954a2be89e7ba39364"
 solve_time = 318013
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.038 }, { type = "claim", txid = "3def611be07c9e5866c9cf293fcb52ca132e56abcd8fa19130bd7a8d5d4b7c28", date = "2015-01-19 10:27:27", amount = 0.038 }]
 
 [[puzzles]]
 bits = 39
-address = "122AJhKLEfkFBaGAd84pLp1kfE7xK3GdT8"
+address = { value = "122AJhKLEfkFBaGAd84pLp1kfE7xK3GdT8", kind = "p2pkh", hash160 = "0b304f2a79a027270276533fe1ed4eff30910876" }
 prize = 0.039
 status = "solved"
 has_pubkey = true
@@ -601,13 +563,12 @@ public_key = "022d77cd1467019a6bf28f7375d0949ce30e6b5815c2758b98a74c2700bc006543
 pubkey_format = "compressed"
 solve_date = "2019-09-07 18:35:38"
 start_date = "2015-01-15 18:07:14"
-h160 = "0b304f2a79a027270276533fe1ed4eff30910876"
 solve_time = 146536104
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.039 }, { type = "claim", txid = "41abfd3419ec99b62c571c05a8183214c1ee21bc35acd0a2f24c4097c62b291f", date = "2015-01-21 06:35:26", amount = 0.039 }]
 
 [[puzzles]]
 bits = 40
-address = "1EeAxcprB2PpCnr34VfZdFrkUWuxyiNEFv"
+address = { value = "1EeAxcprB2PpCnr34VfZdFrkUWuxyiNEFv", kind = "p2pkh", hash160 = "95a156cd21b4a69de969eb6716864f4c8b82a82a" }
 prize = 0.04
 status = "solved"
 has_pubkey = true
@@ -616,13 +577,12 @@ public_key = "03a2efa402fd5268400c77c20e574ba86409ededee7c4020e4b9f0edbee53de0d4
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "95a156cd21b4a69de969eb6716864f4c8b82a82a"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.04 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.04 }]
 
 [[puzzles]]
 bits = 41
-address = "1L5sU9qvJeuwQUdt4y1eiLmquFxKjtHr3E"
+address = { value = "1L5sU9qvJeuwQUdt4y1eiLmquFxKjtHr3E", kind = "p2pkh", hash160 = "d1562eb37357f9e6fc41cb2359f4d3eda4032329" }
 prize = 0.041
 status = "solved"
 has_pubkey = true
@@ -631,13 +591,12 @@ public_key = "03b357e68437da273dcf995a474a524439faad86fc9effc300183f714b0903468b
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "d1562eb37357f9e6fc41cb2359f4d3eda4032329"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.041 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.041 }]
 
 [[puzzles]]
 bits = 42
-address = "1E32GPWgDyeyQac4aJxm9HVoLrrEYPnM4N"
+address = { value = "1E32GPWgDyeyQac4aJxm9HVoLrrEYPnM4N", kind = "p2pkh", hash160 = "8efb85f9c5b5db2d55973a04128dc7510075ae23" }
 prize = 0.042
 status = "solved"
 has_pubkey = true
@@ -646,13 +605,12 @@ public_key = "03eec88385be9da803a0d6579798d977a5d0c7f80917dab49cb73c9e3927142cb6
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "8efb85f9c5b5db2d55973a04128dc7510075ae23"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.042 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.042 }]
 
 [[puzzles]]
 bits = 43
-address = "1PiFuqGpG8yGM5v6rNHWS3TjsG6awgEGA1"
+address = { value = "1PiFuqGpG8yGM5v6rNHWS3TjsG6awgEGA1", kind = "p2pkh", hash160 = "f92044c7924e5525c61207972c253c9fc9f086f7" }
 prize = 0.043
 status = "solved"
 has_pubkey = true
@@ -661,13 +619,12 @@ public_key = "02a631f9ba0f28511614904df80d7f97a4f43f02249c8909dac92276ccf0bcdaed
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "f92044c7924e5525c61207972c253c9fc9f086f7"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.043 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.043 }]
 
 [[puzzles]]
 bits = 44
-address = "1CkR2uS7LmFwc3T2jV8C1BhWb5mQaoxedF"
+address = { value = "1CkR2uS7LmFwc3T2jV8C1BhWb5mQaoxedF", kind = "p2pkh", hash160 = "80df54e1f612f2fc5bdc05c9d21a83aa8d20791e" }
 prize = 0.044
 status = "solved"
 has_pubkey = true
@@ -676,13 +633,12 @@ public_key = "025e466e97ed0e7910d3d90ceb0332df48ddf67d456b9e7303b50a3d89de357336
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "80df54e1f612f2fc5bdc05c9d21a83aa8d20791e"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.044 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.044 }]
 
 [[puzzles]]
 bits = 45
-address = "1NtiLNGegHWE3Mp9g2JPkgx6wUg4TW7bbk"
+address = { value = "1NtiLNGegHWE3Mp9g2JPkgx6wUg4TW7bbk", kind = "p2pkh", hash160 = "f0225bfc68a6e17e87cd8b5e60ae3be18f120753" }
 prize = 0.045
 status = "solved"
 has_pubkey = true
@@ -691,13 +647,12 @@ public_key = "026ecabd2d22fdb737be21975ce9a694e108eb94f3649c586cc7461c8abf5da71a
 pubkey_format = "compressed"
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
-h160 = "f0225bfc68a6e17e87cd8b5e60ae3be18f120753"
 solve_time = 1297024
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.045 }, { type = "claim", txid = "26dbcd4f8bbd5007385fc79954ba238bc684c305d565c60146549bb5acc3f329", date = "2015-01-30 18:24:18", amount = 0.045 }]
 
 [[puzzles]]
 bits = 46
-address = "1F3JRMWudBaj48EhwcHDdpeuy2jwACNxjP"
+address = { value = "1F3JRMWudBaj48EhwcHDdpeuy2jwACNxjP", kind = "p2pkh", hash160 = "9a012260d01c5113df66c8a8438c9f7a1e3d5dac" }
 prize = 0.046
 status = "solved"
 has_pubkey = true
@@ -706,13 +661,12 @@ public_key = "03fd5487722d2576cb6d7081426b66a3e2986c1ce8358d479063fb5f2bb6dd5849
 pubkey_format = "compressed"
 solve_date = "2015-01-30 21:04:12"
 start_date = "2015-01-15 18:07:14"
-h160 = "9a012260d01c5113df66c8a8438c9f7a1e3d5dac"
 solve_time = 1306618
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.046 }, { type = "claim", txid = "ff02b5d1efe2c95c6efadae4384eb7fb654e64b8bef2cbeb3d45774665555504", date = "2015-01-30 21:04:12", amount = 0.046 }]
 
 [[puzzles]]
 bits = 47
-address = "1Pd8VvT49sHKsmqrQiP61RsVwmXCZ6ay7Z"
+address = { value = "1Pd8VvT49sHKsmqrQiP61RsVwmXCZ6ay7Z", kind = "p2pkh", hash160 = "f828005d41b0f4fed4c8dca3b06011072cfb07d4" }
 prize = 0.047
 status = "solved"
 has_pubkey = true
@@ -721,13 +675,12 @@ public_key = "023a12bd3caf0b0f77bf4eea8e7a40dbe27932bf80b19ac72f5f5a64925a594196
 pubkey_format = "compressed"
 solve_date = "2023-08-23 09:42:42"
 start_date = "2015-01-15 18:07:14"
-h160 = "f828005d41b0f4fed4c8dca3b06011072cfb07d4"
 solve_time = 271438528
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.047 }, { type = "claim", txid = "39553513f731ae20f98f3307e863f0aecee9842f22273bb2ddfc0fb6ba481c5e", date = "2015-09-01 20:20:24", amount = 0.047 }]
 
 [[puzzles]]
 bits = 48
-address = "1DFYhaB2J9q1LLZJWKTnscPWos9VBqDHzv"
+address = { value = "1DFYhaB2J9q1LLZJWKTnscPWos9VBqDHzv", kind = "p2pkh", hash160 = "8661cb56d9df0a61f01328b55af7e56a3fe7a2b2" }
 prize = 0.048
 status = "solved"
 has_pubkey = true
@@ -736,13 +689,12 @@ public_key = "0291bee5cf4b14c291c650732faa166040e4c18a14731f9a930c1e87d3ec12debb
 pubkey_format = "compressed"
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
-h160 = "8661cb56d9df0a61f01328b55af7e56a3fe7a2b2"
 solve_time = 19793590
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.048 }, { type = "claim", txid = "39553513f731ae20f98f3307e863f0aecee9842f22273bb2ddfc0fb6ba481c5e", date = "2015-09-01 20:20:24", amount = 0.048 }]
 
 [[puzzles]]
 bits = 49
-address = "12CiUhYVTTH33w3SPUBqcpMoqnApAV4WCF"
+address = { value = "12CiUhYVTTH33w3SPUBqcpMoqnApAV4WCF", kind = "p2pkh", hash160 = "0d2f533966c6578e1111978ca698f8add7fffdf3" }
 prize = 0.049
 status = "solved"
 has_pubkey = true
@@ -751,13 +703,12 @@ public_key = "02591d682c3da4a2a698633bf5751738b67c343285ebdc3492645cb44658911484
 pubkey_format = "compressed"
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
-h160 = "0d2f533966c6578e1111978ca698f8add7fffdf3"
 solve_time = 19793590
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.049 }, { type = "claim", txid = "39553513f731ae20f98f3307e863f0aecee9842f22273bb2ddfc0fb6ba481c5e", date = "2015-09-01 20:20:24", amount = 0.049 }]
 
 [[puzzles]]
 bits = 50
-address = "1MEzite4ReNuWaL5Ds17ePKt2dCxWEofwk"
+address = { value = "1MEzite4ReNuWaL5Ds17ePKt2dCxWEofwk", kind = "p2pkh", hash160 = "de081b76f840e462fa2cdf360173dfaf4a976a47" }
 prize = 0.05
 status = "solved"
 has_pubkey = true
@@ -766,13 +717,12 @@ public_key = "03f46f41027bbf44fafd6b059091b900dad41e6845b2241dc3254c7cdd3c5a16c6
 pubkey_format = "compressed"
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
-h160 = "de081b76f840e462fa2cdf360173dfaf4a976a47"
 solve_time = 19793590
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.05 }, { type = "claim", txid = "39553513f731ae20f98f3307e863f0aecee9842f22273bb2ddfc0fb6ba481c5e", date = "2015-09-01 20:20:24", amount = 0.05 }]
 
 [[puzzles]]
 bits = 51
-address = "1NpnQyZ7x24ud82b7WiRNvPm6N8bqGQnaS"
+address = { value = "1NpnQyZ7x24ud82b7WiRNvPm6N8bqGQnaS", kind = "p2pkh", hash160 = "ef6419cffd7fad7027994354eb8efae223c2dbe7" }
 prize = 0.051
 status = "solved"
 has_pubkey = true
@@ -781,13 +731,12 @@ public_key = "028c6c67bef9e9eebe6a513272e50c230f0f91ed560c37bc9b033241ff6c3be78f
 pubkey_format = "compressed"
 solve_date = "2017-04-05 10:45:32"
 start_date = "2015-01-15 18:07:14"
-h160 = "ef6419cffd7fad7027994354eb8efae223c2dbe7"
 solve_time = 70043898
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.051 }, { type = "claim", txid = "70ee9ab241829a6f49ebf9f109e97f6e466d938e558bade1c5fe341310bc356e", date = "2017-04-05 10:11:20", amount = 0.051 }]
 
 [[puzzles]]
 bits = 52
-address = "15z9c9sVpu6fwNiK7dMAFgMYSK4GqsGZim"
+address = { value = "15z9c9sVpu6fwNiK7dMAFgMYSK4GqsGZim", kind = "p2pkh", hash160 = "36af659edbe94453f6344e920d143f1778653ae7" }
 prize = 0.052
 status = "solved"
 has_pubkey = true
@@ -796,13 +745,12 @@ public_key = "0374c33bd548ef02667d61341892134fcf216640bc2201ae61928cd0874f6314a7
 pubkey_format = "compressed"
 solve_date = "2017-04-21 18:10:05"
 start_date = "2015-01-15 18:07:14"
-h160 = "36af659edbe94453f6344e920d143f1778653ae7"
 solve_time = 71452971
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.052 }, { type = "claim", txid = "b0df330141225a2253c375b7b6c36c0016a9633934295916df6b0fd31afb4a8b", date = "2017-04-21 18:10:05", amount = 0.052 }]
 
 [[puzzles]]
 bits = 53
-address = "15K1YKJMiJ4fpesTVUcByoz334rHmknxmT"
+address = { value = "15K1YKJMiJ4fpesTVUcByoz334rHmknxmT", kind = "p2pkh", hash160 = "2f4870ef54fa4b048c1365d42594cc7d3d269551" }
 prize = 0.53
 status = "solved"
 has_pubkey = true
@@ -811,13 +759,12 @@ public_key = "020faaf5f3afe58300a335874c80681cf66933e2a7aeb28387c0d28bb048bc6349
 pubkey_format = "compressed"
 solve_date = "2017-09-04 20:23:27"
 start_date = "2015-01-15 18:07:14"
-h160 = "2f4870ef54fa4b048c1365d42594cc7d3d269551"
 solve_time = 83211373
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.053 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.477 }, { type = "claim", txid = "0e343c3640fa8cc1f7a97556255f46a08b89bd7d1b62ca94b86b37e51835b3b3", date = "2017-09-04 20:23:27", amount = 0.53 }]
 
 [[puzzles]]
 bits = 54
-address = "1KYUv7nSvXx4642TKeuC2SNdTk326uUpFy"
+address = { value = "1KYUv7nSvXx4642TKeuC2SNdTk326uUpFy", kind = "p2pkh", hash160 = "cb66763cf7fde659869ae7f06884d9a0f879a092" }
 prize = 0.54
 status = "solved"
 has_pubkey = true
@@ -826,13 +773,12 @@ public_key = "034af4b81f8c450c2c870ce1df184aff1297e5fcd54944d98d81e1a545ffb22596
 pubkey_format = "compressed"
 solve_date = "2018-07-11 06:20:58"
 start_date = "2015-01-15 18:07:14"
-h160 = "cb66763cf7fde659869ae7f06884d9a0f879a092"
 solve_time = 109944824
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.054 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.486 }, { type = "claim", txid = "02e9c6ccae985a6485e633b56a084dae2a32736e5b866c3b9622db9d3c57078f", date = "2017-11-16 11:04:22", amount = 0.54 }]
 
 [[puzzles]]
 bits = 55
-address = "1LzhS3k3e9Ub8i2W1V8xQFdB8n2MYCHPCa"
+address = { value = "1LzhS3k3e9Ub8i2W1V8xQFdB8n2MYCHPCa", kind = "p2pkh", hash160 = "db53d9bbd1f3a83b094eeca7dd970bd85b492fa2" }
 prize = 0.55
 status = "solved"
 has_pubkey = true
@@ -841,13 +787,12 @@ public_key = "0385a30d8413af4f8f9e6312400f2d194fe14f02e719b24c3f83bf1fd233a8f963
 pubkey_format = "compressed"
 solve_date = "2018-05-30 08:43:35"
 start_date = "2015-01-15 18:07:14"
-h160 = "db53d9bbd1f3a83b094eeca7dd970bd85b492fa2"
 solve_time = 106324581
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.055 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.495 }, { type = "increase", txid = "0cec4460b09db31a00ff1475c32b6a02a89fde2ff89d8ff8fd79535a21474d90", date = "2018-03-11 04:50:13", amount = 0.00011515 }, { type = "claim", txid = "ecc8c09284a6f9e6d52cccf7f8f4aef1d0c4a33984375dea4cea70923066078d", date = "2018-05-29 08:13:52", amount = 0.55011515 }]
 
 [[puzzles]]
 bits = 56
-address = "17aPYR1m6pVAacXg1PTDDU7XafvK1dxvhi"
+address = { value = "17aPYR1m6pVAacXg1PTDDU7XafvK1dxvhi", kind = "p2pkh", hash160 = "48214c5969ae9f43f75070cea1e2cb41d5bdcccd" }
 prize = 0.56
 status = "solved"
 has_pubkey = true
@@ -856,13 +801,12 @@ public_key = "033f2db2074e3217b3e5ee305301eeebb1160c4fa1e993ee280112f6348637999a
 pubkey_format = "compressed"
 solve_date = "2018-09-08 08:01:09"
 start_date = "2015-01-15 18:07:14"
-h160 = "48214c5969ae9f43f75070cea1e2cb41d5bdcccd"
 solve_time = 115048435
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.056 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.504 }, { type = "claim", txid = "5317fdbea32034f8f983bd2324e99e5da593aaf3c4aed6425d8104dc3b8c77d2", date = "2018-09-08 05:45:09", amount = 0.504 }]
 
 [[puzzles]]
 bits = 57
-address = "15c9mPGLku1HuW9LRtBf4jcHVpBUt8txKz"
+address = { value = "15c9mPGLku1HuW9LRtBf4jcHVpBUt8txKz", kind = "p2pkh", hash160 = "328660ef43f66abe2653fa178452a5dfc594c2a1" }
 prize = 0.57
 status = "solved"
 has_pubkey = true
@@ -871,13 +815,12 @@ public_key = "02a521a07e98f78b03fc1e039bc3a51408cd73119b5eb116e583fe57dc8db07aea
 pubkey_format = "compressed"
 solve_date = "2018-11-08 01:03:19"
 start_date = "2015-01-15 18:07:14"
-h160 = "328660ef43f66abe2653fa178452a5dfc594c2a1"
 solve_time = 120293765
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.057 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.513 }, { type = "claim", txid = "fd773819f5fb5d672d32bfe99e30af086e86c2c2b35dd7cfe337bf8960a96aa7", date = "2018-11-08 01:03:19", amount = 0.57 }]
 
 [[puzzles]]
 bits = 58
-address = "1Dn8NF8qDyyfHMktmuoQLGyjWmZXgvosXf"
+address = { value = "1Dn8NF8qDyyfHMktmuoQLGyjWmZXgvosXf", kind = "p2pkh", hash160 = "8c2a6071f89c90c4dab5ab295d7729d1b54ea60f" }
 prize = 0.58
 status = "solved"
 has_pubkey = true
@@ -886,13 +829,12 @@ public_key = "0311569442e870326ceec0de24eb5478c19e146ecd9d15e4666440f2f638875f42
 pubkey_format = "compressed"
 solve_date = "2025-02-17 06:19:03"
 start_date = "2015-01-15 18:07:14"
-h160 = "8c2a6071f89c90c4dab5ab295d7729d1b54ea60f"
 solve_time = 318427909
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.058 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.522 }, { type = "claim", txid = "17d31de2bd300bc1bad430ec0db77ca27466bbb97bf03df6a3ff386d60e58996", date = "2018-12-03 06:03:22", amount = 0.58 }]
 
 [[puzzles]]
 bits = 59
-address = "1HAX2n9Uruu9YDt4cqRgYcvtGvZj1rbUyt"
+address = { value = "1HAX2n9Uruu9YDt4cqRgYcvtGvZj1rbUyt", kind = "p2pkh", hash160 = "b14ed3146f5b2c9bde1703deae9ef33af8110210" }
 prize = 0.59
 status = "solved"
 has_pubkey = true
@@ -901,13 +843,12 @@ public_key = "0241267d2d7ee1a8e76f8d1546d0d30aefb2892d231cee0dde7776daf9f8021485
 pubkey_format = "compressed"
 solve_date = "2024-07-20 23:43:09"
 start_date = "2015-01-15 18:07:14"
-h160 = "b14ed3146f5b2c9bde1703deae9ef33af8110210"
 solve_time = 300173755
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.059 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.531 }, { type = "claim", txid = "66cd4fd4b240df28c5f61c4c86865f57e5f4e203dc8ea36d520e553e61d96e04", date = "2019-02-11 22:39:32", amount = 0.59 }]
 
 [[puzzles]]
 bits = 60
-address = "1Kn5h2qpgw9mWE5jKpk8PP4qvvJ1QVy8su"
+address = { value = "1Kn5h2qpgw9mWE5jKpk8PP4qvvJ1QVy8su", kind = "p2pkh", hash160 = "cdf8e5c7503a9d22642e3ecfc87817672787b9c5" }
 prize = 0.6
 status = "solved"
 has_pubkey = true
@@ -916,13 +857,12 @@ public_key = "0348e843dc5b1bd246e6309b4924b81543d02b16c8083df973a89ce2c7eb89a10d
 pubkey_format = "compressed"
 solve_date = "2019-02-17 11:59:52"
 start_date = "2015-01-15 18:07:14"
-h160 = "cdf8e5c7503a9d22642e3ecfc87817672787b9c5"
 solve_time = 129059558
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.06 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.54 }, { type = "claim", txid = "6c08747ecd15904128c3f15f3bf47f6f365405da2661f17eb5119008807cee3e", date = "2019-02-17 11:59:52", amount = 0.6 }]
 
 [[puzzles]]
 bits = 61
-address = "1AVJKwzs9AskraJLGHAZPiaZcrpDr1U6AB"
+address = { value = "1AVJKwzs9AskraJLGHAZPiaZcrpDr1U6AB", kind = "p2pkh", hash160 = "68133e19b2dfb9034edf9830a200cfdf38c90cbd" }
 prize = 0.61
 status = "solved"
 has_pubkey = true
@@ -931,13 +871,12 @@ public_key = "0249a43860d115143c35c09454863d6f82a95e47c1162fb9b2ebe0186eb26f453f
 pubkey_format = "compressed"
 solve_date = "2019-05-12 18:32:07"
 start_date = "2015-01-15 18:07:14"
-h160 = "68133e19b2dfb9034edf9830a200cfdf38c90cbd"
 solve_time = 136340693
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.061 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.549 }, { type = "increase", txid = "cdae2da8fe4b18dc264e568a29e804f2b32529b8018a9d28e271ac7e9077c718", date = "2019-02-24 21:48:34", amount = 0.00000793 }, { type = "claim", txid = "481d2b7ceb253520336fbbe681126ae58d14ecd552320d88203b2e806e76358d", date = "2019-05-11 12:53:18", amount = 0.61 }]
 
 [[puzzles]]
 bits = 62
-address = "1Me6EfpwZK5kQziBwBfvLiHjaPGxCKLoJi"
+address = { value = "1Me6EfpwZK5kQziBwBfvLiHjaPGxCKLoJi", kind = "p2pkh", hash160 = "e26646db84b0602f32b34b5a62ca3cae1f91b779" }
 prize = 0.62
 status = "solved"
 has_pubkey = true
@@ -946,13 +885,12 @@ public_key = "03231a67e424caf7d01a00d5cd49b0464942255b8e48766f96602bdfa4ea14fea8
 pubkey_format = "compressed"
 solve_date = "2019-09-08 10:51:01"
 start_date = "2015-01-15 18:07:14"
-h160 = "e26646db84b0602f32b34b5a62ca3cae1f91b779"
 solve_time = 146594627
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.062 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.558 }, { type = "increase", txid = "1377682be6c1b875153d7c2d5bceb9985cdf6b6d1054d96b20c4e8ccc7963195", date = "2019-06-11 10:21:45", amount = 0.000061 }, { type = "increase", txid = "c6c7ec1a1435c9f049857fc8cf37ab14b90ee2a83e28e9bd059175ae17e955f8", date = "2019-06-20 19:31:16", amount = 0.00001 }, { type = "increase", txid = "c725a765997cf82ca4a40cb2166f9ed2c2677e9ad9446112dd94920db7034a07", date = "2019-06-20 20:49:30", amount = 0.00001 }, { type = "increase", txid = "9623ca8da4f10db5ca90a0673674571a3150e568cb82c2e2ad6ca55af77a67f9", date = "2019-06-20 21:20:44", amount = 0.00001 }, { type = "claim", txid = "d96269bdbae871174f629f4ec136d8c2c99cb1a1db15d12903418dfc92df5465", date = "2019-09-08 10:51:01", amount = 0.620091 }]
 
 [[puzzles]]
 bits = 63
-address = "1NpYjtLira16LfGbGwZJ5JbDPh3ai9bjf4"
+address = { value = "1NpYjtLira16LfGbGwZJ5JbDPh3ai9bjf4", kind = "p2pkh", hash160 = "ef58afb697b094423ce90721fbb19a359ef7c50e" }
 prize = 0.63
 status = "solved"
 has_pubkey = true
@@ -961,13 +899,12 @@ public_key = "0365ec2994b8cc0a20d40dd69edfe55ca32a54bcbbaa6b0ddcff36049301a54579
 pubkey_format = "compressed"
 solve_date = "2020-04-27 01:47:22"
 start_date = "2015-01-15 18:07:14"
-h160 = "ef58afb697b094423ce90721fbb19a359ef7c50e"
 solve_time = 166606808
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.063 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.567 }, { type = "increase", txid = "5738c12f1c607609b6a33b870981c79d67bbbe4e43bfdf0799f7efd5d866aac2", date = "2019-06-20 19:31:16", amount = 0.00001 }, { type = "increase", txid = "c725a765997cf82ca4a40cb2166f9ed2c2677e9ad9446112dd94920db7034a07", date = "2019-06-20 20:49:30", amount = 0.00001 }, { type = "increase", txid = "9623ca8da4f10db5ca90a0673674571a3150e568cb82c2e2ad6ca55af77a67f9", date = "2019-06-20 21:20:44", amount = 0.00001 }, { type = "claim", txid = "195876f004cb9cfa4ff22f4d3df94feda86c5a481fde6979889ea568ac2ca4ac", date = "2019-07-12 12:26:39", amount = 0.63003 }]
 
 [[puzzles]]
 bits = 64
-address = "16jY7qLJnxb7CHZyqBP8qca9d51gAjyXQN"
+address = { value = "16jY7qLJnxb7CHZyqBP8qca9d51gAjyXQN", kind = "p2pkh", hash160 = "3ee4133d991f52fdf6a25c9834e0745ac74248a4" }
 prize = 0.64
 status = "solved"
 has_pubkey = true
@@ -976,13 +913,12 @@ public_key = "03100611c54dfef604163b8358f7b7fac13ce478e02cb224ae16d45526b25d9d4d
 pubkey_format = "compressed"
 solve_date = "2022-09-09 22:49:03"
 start_date = "2015-01-15 18:07:14"
-h160 = "3ee4133d991f52fdf6a25c9834e0745ac74248a4"
 solve_time = 241418509
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.064 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.576 }, { type = "increase", txid = "c725a765997cf82ca4a40cb2166f9ed2c2677e9ad9446112dd94920db7034a07", date = "2019-06-20 20:49:30", amount = 0.00001 }, { type = "increase", txid = "9623ca8da4f10db5ca90a0673674571a3150e568cb82c2e2ad6ca55af77a67f9", date = "2019-06-20 21:20:44", amount = 0.00001 }, { type = "increase", txid = "ed53ace1d284e1b9c5b2058fd296ee7d5be43efd6ce87d0a03adfe039c171e28", date = "2019-10-31 00:45:03", amount = 0.00000564 }, { type = "increase", txid = "5815ecc9699c32adbfc77e2f7bd0e35c87e3ffeacd248cac7eb35452b49d508d", date = "2020-11-23 03:00:39", amount = 0.00001 }, { type = "increase", txid = "e6e7ee7bcb9a9b616121faa56cdd6e8a1d9c5fd93a67b41c93c705d396b8ea26", date = "2020-12-08 18:48:04", amount = 0.00012 }, { type = "increase", txid = "776b63fc5506eb23ec7aec5b89db0c51c228a3c592939af1a6f802faa97f5d13", date = "2020-12-20 05:03:18", amount = 0.00001 }, { type = "increase", txid = "7696793c052f4ed3362a0036f8cb7aa11302c134f2e4af2eae933af54809969c", date = "2021-05-07 22:44:07", amount = 0.00002021 }, { type = "increase", txid = "8058cbfcbe89688aaac3a48c65f461a3efa5e09c536b4c4211b4030f311588b3", date = "2021-08-29 11:30:32", amount = 0.00002 }, { type = "increase", txid = "5ba85ff53e1c4816d96490d9b4ff06cd8b07751298a846e7579131c5973d348b", date = "2022-02-22 11:26:14", amount = 0.00000696 }, { type = "increase", txid = "07af703e54e326116144536a2da7fe732224cb07de96d99be9031b443e74a619", date = "2022-03-31 20:58:56", amount = 0.0000101 }, { type = "increase", txid = "294e3134d6fbb970131236ca947965b23b5bfb8e1e5eeb070b567f06a903f4e3", date = "2022-05-17 19:19:30", amount = 0.00000642 }, { type = "increase", txid = "a63f1b15dd736529b29f92b443bf401c41d190403923f8fc913d377c2acea1c4", date = "2022-06-01 00:14:56", amount = 0.00010026 }, { type = "claim", txid = "9c1d797c34e3b04f9b721bac45fe3a410393bdd25d169bc62dcbca46b069fa9f", date = "2022-09-09 22:49:03", amount = 0.64032959 }]
 
 [[puzzles]]
 bits = 65
-address = "18ZMbwUFLMHoZBbfpCjUJQTCMCbktshgpe"
+address = { value = "18ZMbwUFLMHoZBbfpCjUJQTCMCbktshgpe", kind = "p2pkh", hash160 = "52e763a7ddc1aa4fa811578c491c1bc7fd570137" }
 prize = 0.65
 status = "solved"
 has_pubkey = true
@@ -991,13 +927,12 @@ public_key = "0230210c23b1a047bc9bdbb13448e67deddc108946de6de639bcc75d47c0216b1b
 pubkey_format = "compressed"
 solve_date = "2024-11-06 17:12:30"
 start_date = "2015-01-15 18:07:14"
-h160 = "52e763a7ddc1aa4fa811578c491c1bc7fd570137"
 solve_time = 309567916
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.065 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.585 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "43bb89f7d16fb47fee3eaeee0fa26aa2d0d6874c8907b2eca4ec2420bf4a9dc3", date = "2019-06-07 16:39:02", amount = 0.65 }]
 
 [[puzzles]]
 bits = 66
-address = "13zb1hQbWVsc2S7ZTZnP2G4undNNpdh5so"
+address = { value = "13zb1hQbWVsc2S7ZTZnP2G4undNNpdh5so", kind = "p2pkh", hash160 = "20d45a6a762535700ce9e0b216e31994335db8a5" }
 prize = 6.6
 status = "solved"
 has_pubkey = true
@@ -1006,14 +941,13 @@ public_key = "024ee2be2d4e9f92d2f5a4a03058617dc45befe22938feed5b7a6b7282dd74cbdd
 pubkey_format = "compressed"
 solve_date = "2025-02-19 04:19:52"
 start_date = "2015-01-15 18:07:14"
-h160 = "20d45a6a762535700ce9e0b216e31994335db8a5"
 solve_time = 318593558
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.066 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.594 }, { type = "increase", txid = "c725a765997cf82ca4a40cb2166f9ed2c2677e9ad9446112dd94920db7034a07", date = "2019-06-20 20:49:30", amount = 0.00001 }, { type = "increase", txid = "9623ca8da4f10db5ca90a0673674571a3150e568cb82c2e2ad6ca55af77a67f9", date = "2019-06-20 21:20:44", amount = 0.00001 }, { type = "increase", txid = "ab571acb61ec96a4759da551ae37a1fe5accbd353dfca3e1a57cb254e5e0e790", date = "2019-10-31 20:18:31", amount = 0.00000666 }, { type = "increase", txid = "33ea377a3c0aa2e10f498a41f746d7489e06bf9b6e45b406b817ee96e4cec96b", date = "2021-01-18 01:01:38", amount = 0.0000195 }, { type = "increase", txid = "4461b388764735edf0b8b35456846c251dc7e281a8837df42f684b4bfce91f72", date = "2022-09-25 04:13:35", amount = 0.00001 }, { type = "increase", txid = "c1a490e56f7faea9c064fd30023647780d5b3fa330cd7ec10c60c513c3f36813", date = "2022-10-18 11:43:20", amount = 0.00001533 }, { type = "increase", txid = "1602e46f048a7466db2f630f74e6f83a6e72fb2726067ac719c7de3ab784689c", date = "2022-10-31 14:29:20", amount = 0.000006 }, { type = "increase", txid = "3615aa6fc46e190a9d542844172a105191c902402ff753c96f6bd591ea2aecad", date = "2022-11-19 16:31:43", amount = 0.00001 }, { type = "increase", txid = "acdf413e69ab69a2628e50225096f14fab57483b1d908387e00d593d56abe425", date = "2023-02-23 03:23:43", amount = 0.00000908 }, { type = "increase", txid = "7cce2dde07daaa77a0c2159ae079cf56a1b9ca8196c0b122666d3d40d5314e22", date = "2023-03-01 22:38:23", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 5.94 }, { type = "increase", txid = "a453faa9ef528a3b7918f79f01c07c3fe93f2b8f3d193c89e29a69f40f53b577", date = "2023-04-27 04:47:38", amount = 0.00003526 }, { type = "increase", txid = "b33947a7c57fc75ecf94bf4b8809ed0d8cc2c8c0ac0008cfe44c91ebd6854605", date = "2023-04-30 05:02:59", amount = 0.00001279 }, { type = "increase", txid = "085fd326dc36377342bbe915533c3c94453875a4408ae9f9f60025e2793b98e1", date = "2023-05-03 14:39:54", amount = 0.00013364 }, { type = "increase", txid = "236806fad5606e2a496b6671868f3d4efd77f3b4da7942322b62ebff3a00028b", date = "2023-07-27 19:04:45", amount = 0.00002869 }, { type = "increase", txid = "cf7ad170e2f58aea83686095607b12a04cbef15679383a11c124d953bd2c5a6d", date = "2023-08-25 08:22:59", amount = 0.00000749 }, { type = "increase", txid = "f3db7c0088b6d2f357008854441cfab93583d4cc0d4dc026de0f158f7ce5ac9b", date = "2023-09-25 15:00:17", amount = 0.00003769 }, { type = "increase", txid = "6a76cd295c5fe4037511c2e5c2945b99aa52e2fd41d014943c0a975e08a5ce17", date = "2024-02-19 11:23:46", amount = 0.000067 }, { type = "increase", txid = "8da7b3599f9fec422ace5d290443c17f685d6e45ce89ca1ee0a334b711f10745", date = "2024-03-12 21:29:44", amount = 0.0000066 }, { type = "increase", txid = "8cc982de6db7539fa665840ff774d69807a9d85c01e17620205da67de995ea29", date = "2024-03-14 03:22:22", amount = 0.00001277 }, { type = "increase", txid = "cff6de5c21176e8cb9d60fcf1e2a2d9a44b9267860126cfddee5d7fa39ab27e1", date = "2024-03-21 10:13:55", amount = 0.00006018 }, { type = "increase", txid = "55571ca5e1f86c11a5ec5837aa1edf4262042b4b18379373585047ce8f8938cf", date = "2024-05-12 00:07:46", amount = 0.00000546 }, { type = "increase", txid = "acdeeb926e2eacd19024867cd7df0b4339c4940687c8562853ef499683f0a064", date = "2024-05-18 14:37:26", amount = 0.0000812 }, { type = "increase", txid = "b6064fe616abb0221da96652bbdce82b545e4069084cdcdb5cad717b2f301bd2", date = "2024-06-27 20:23:46", amount = 0.00001629 }, { type = "increase", txid = "7e8c361a44646e7016d316ce777f838f15cd1cf7440684e884bf37c28f97a642", date = "2024-07-14 01:09:57", amount = 0.00008382 }, { type = "increase", txid = "4bac263083823b95b8cac1ece40e5c288bb084eb94efba1b2d73b6dcb6ac30e3", date = "2024-07-14 05:10:53", amount = 0.000006 }, { type = "increase", txid = "95dd4f8609851cd7477a5b2e8744a18b7e24e9c8adcb964a4dcaa6e360f17690", date = "2024-07-25 13:54:46", amount = 0.0000066 }, { type = "increase", txid = "25f02f5997e30cacce3efda3036803fec56c41e96634551ea814a93075a675b4", date = "2024-07-25 15:11:25", amount = 0.0000066 }, { type = "increase", txid = "0c10efa88389fd8d3ec14930270a1a5bfaab55488e0014cbec092e42a01ab416", date = "2024-08-03 20:47:01", amount = 0.000016 }, { type = "increase", txid = "1e298e15cc35a3b195e79acc602cd3e1c503c616ba1bf3a19e1cd0feb1e8db71", date = "2024-08-19 06:46:05", amount = 0.0005 }, { type = "increase", txid = "1384102b7955d1c56a2501641d619fccc253a2270003ac6a1d42ad0fde3bb8d7", date = "2024-08-19 10:45:37", amount = 0.000015 }, { type = "increase", txid = "619e8eca7bf5ce834f5cee2f49c6cbf4e32a8ec697f49230172691ef1686c024", date = "2024-09-08 12:46:11", amount = 0.00001448 }, { type = "claim", txid = "57a88f47e4c047740b782a5562fca143ce85de0373cbff3a7d406e9ae7fc2f5f", date = "2024-09-12 22:59:39", amount = 5.94 }]
 solver = { address = "bc1qpkp47q5cucrvnyepsdnjcv2kzyav5ze0ta7n67" }
 
 [[puzzles]]
 bits = 67
-address = "1BY8GQbnueYofwSuFAT3USAhGjPrkxDdW9"
+address = { value = "1BY8GQbnueYofwSuFAT3USAhGjPrkxDdW9", kind = "p2pkh", hash160 = "739437bb3dd6d1983e66629c5f08c70e52769371" }
 prize = 6.7
 status = "solved"
 has_pubkey = true
@@ -1022,14 +956,13 @@ public_key = "0212209f5ec514a1580a2937bd833979d933199fc230e204c6cdc58872b7d46f75
 pubkey_format = "compressed"
 solve_date = "2025-02-21 01:41:01"
 start_date = "2015-01-15 18:07:14"
-h160 = "739437bb3dd6d1983e66629c5f08c70e52769371"
 solve_time = 318756827
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.067 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.603 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.03 }, { type = "increase", txid = "63da7a056b214b7de07511366662a889cc916dde2b7421fc4606bc1ed63e6fc6", date = "2023-09-25 15:00:17", amount = 0.00003769 }, { type = "increase", txid = "55571ca5e1f86c11a5ec5837aa1edf4262042b4b18379373585047ce8f8938cf", date = "2024-05-12 00:07:46", amount = 0.00000546 }, { type = "increase", txid = "69888f5e55d414b8de65f3a9307a1f414d7035cf9142239045300ce018984bd4", date = "2024-09-24 16:44:24", amount = 0.00003703 }, { type = "increase", txid = "ee5bf15d6e65f87353d46cd084b4f3052d8315c6a157ef757acff58f8b5b2429", date = "2024-10-17 00:54:49", amount = 0.00002 }, { type = "increase", txid = "d26e3fdad584be13a085094c0668a61f84326a5f9ec316baaf2ce7931b8a8863", date = "2024-10-21 01:11:34", amount = 0.00000678 }, { type = "increase", txid = "22e955db5c02e10f89045df063af7c320b8e813916cb974d4452fd5eed57687a", date = "2025-01-28 07:27:07", amount = 0.000006 }, { type = "increase", txid = "354a780bb64d0c953262389833531c32e45a6e041fddff43babf0f7360c7adfb", date = "2025-02-05 09:09:28", amount = 0.00000398 }, { type = "increase", txid = "d528fad306f89d7e2cafc8474dc9c1579bd4ae2f9a4f3f19c7a30fef6410d5b4", date = "2025-02-11 14:13:02", amount = 0.00000547 }, { type = "increase", txid = "222f724a59f4bb8e3d6ed81bf07a13a65bed21b2d33843d2654e221bdba8f7ce", date = "2025-02-11 14:20:07", amount = 0.00001 }, { type = "claim", txid = "0be77ec8bec331da8750c8b715085c6cf6c374ca31f829a515c62b9846e32986", date = "2025-02-21 01:41:01", amount = 6.70013241 }]
 solver = { address = "bc1qfk357t8n045f8mwx672rx2re4pftm5gmjzdwq7" }
 
 [[puzzles]]
 bits = 68
-address = "1MVDYgVaSN6iKKEsbzRUAYFrYJadLYZvvZ"
+address = { value = "1MVDYgVaSN6iKKEsbzRUAYFrYJadLYZvvZ", kind = "p2pkh", hash160 = "e0b8a2baee1b77fc703455f39d51477451fc8cfc" }
 prize = 6.8
 status = "solved"
 has_pubkey = true
@@ -1038,14 +971,13 @@ public_key = "031fe02f1d740637a7127cdfe8a77a8a0cfc6435f85e7ec3282cb6243c0a93ba1b
 pubkey_format = "compressed"
 solve_date = "2025-04-06 22:52:42"
 start_date = "2015-01-15 18:07:14"
-h160 = "e0b8a2baee1b77fc703455f39d51477451fc8cfc"
 solve_time = 322634728
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.068 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.612 }, { type = "increase", txid = "65264bade4a3cf484d649b058a6482fc66bbf3b710d342c83fdf311e97567b05", date = "2023-03-26 00:46:41", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.12 }, { type = "increase", txid = "e2d8d24e4ce591bebc0dd92c55596d4e6f21e38ce4118de9625cad351a732ce5", date = "2023-09-25 15:00:17", amount = 0.00003768 }, { type = "increase", txid = "55571ca5e1f86c11a5ec5837aa1edf4262042b4b18379373585047ce8f8938cf", date = "2024-05-12 00:07:46", amount = 0.00000546 }, { type = "increase", txid = "82663b99c18c61a81515342df76ad42560d9c3a91bdc5695830a114c874e94b1", date = "2025-01-28 07:26:42", amount = 0.000006 }, { type = "increase", txid = "d8ac1247594800c6de2cf8fe72bf0a8431016af708a741b46c753a16c9a855b3", date = "2025-02-04 12:20:30", amount = 0.00001 }, { type = "increase", txid = "2ae40c9480cd4608754636bf14ae0b978e589b59f38f9e48a21f03bd084ce622", date = "2025-03-06 21:44:48", amount = 0.00000001 }, { type = "increase", txid = "6907f589ffc4eb2889f154c292c3ae54cb046b395066485d6d598dddd88e38d0", date = "2025-03-07 06:51:25", amount = 0.000022 }, { type = "increase", txid = "5be41d92b4a9829e2555cf7389dfc8f62209a1ff7f60bae5634518f5287d881f", date = "2025-03-16 03:24:47", amount = 0.00000001 }, { type = "increase", txid = "42cfb3573cdb540cffdca9376802234bf04e843c1dfaae9a877447c57626e286", date = "2025-03-22 03:10:27", amount = 0.00000833 }, { type = "increase", txid = "0f58191b0bedc574e0ca12026f66066f6a919aa4687d7216b89812ca64eaa5bb", date = "2025-03-28 20:09:27", amount = 0.000008 }, { type = "increase", txid = "0e0fe0335638be35190b4b251d2ae67579feb5a14774cbcd4180b40b9a793a3c", date = "2025-03-29 01:18:50", amount = 0.00000666 }, { type = "increase", txid = "aff11a074048fba3b545f1498d0b0d32dd2f2309864deb4550d4dd29727324b4", date = "2025-03-29 11:13:43", amount = 0.00000775 }, { type = "increase", txid = "017cfc42405a2dae6417b9137e452268f1d936ef7410c1b5e387dee755387edb", date = "2025-03-29 16:41:47", amount = 0.00000647 }, { type = "increase", txid = "e3b4d2f6971099039b7b47869bdc2217fc37119bf98fbe2e44be85cc29c133c1", date = "2025-03-30 00:50:59", amount = 0.00000775 }, { type = "increase", txid = "4328caeff6a8679a6a64e9b835d3c08ab26554c4b89042c77581f7a6904f0eb9", date = "2025-03-30 01:23:03", amount = 0.00000783 }, { type = "increase", txid = "47e20f8b984c3bf2740ab724204d3fe74ce8f1fc68f0060967ef7d94e0e16504", date = "2025-03-30 01:23:03", amount = 0.00000771 }, { type = "increase", txid = "285a933772c91d5202225015ed6fc9f8a24f3140042a0893dead42ce140e4e14", date = "2025-04-03 06:38:53", amount = 0.00000001 }, { type = "claim", txid = "a5635eb2205bd3024e55156ee353110415829d1c6bc947f42bfa162488b0eb08", date = "2025-04-06 22:52:42", amount = 6.80015167 }]
 solver = { address = "bc1qfwpccz2udt3efk7y2wt9l44h34cs5yevjc80lk" }
 
 [[puzzles]]
 bits = 69
-address = "19vkiEajfhuZ8bs8Zu2jgmC6oqZbWqhxhG"
+address = { value = "19vkiEajfhuZ8bs8Zu2jgmC6oqZbWqhxhG", kind = "p2pkh", hash160 = "61eb8a50c86b0584bb727dd65bed8d2400d6d5aa" }
 prize = 6.9
 status = "solved"
 has_pubkey = true
@@ -1054,14 +986,13 @@ public_key = "024babadccc6cfd5f0e5e7fd2a50aa7d677ce0aa16fdce26a0d0882eed03e7ba53
 pubkey_format = "compressed"
 solve_date = "2025-06-25 05:04:52"
 start_date = "2015-01-15 18:07:14"
-h160 = "61eb8a50c86b0584bb727dd65bed8d2400d6d5aa"
 solve_time = 329482658
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.069 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.621 }, { type = "increase", txid = "0401d3fd3016076ac5a81dc51b3b6198375ae70c3e7b63be2f33ae9469b7527e", date = "2022-04-01 06:05:22", amount = 0.00000547 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.21 }, { type = "increase", txid = "a9334d335e59aa30832d57641085d0ff4c61a26fc16c4bed22368b0659539463", date = "2023-09-25 15:00:17", amount = 0.00003768 }, { type = "increase", txid = "55571ca5e1f86c11a5ec5837aa1edf4262042b4b18379373585047ce8f8938cf", date = "2024-05-12 00:07:46", amount = 0.00000546 }, { type = "increase", txid = "e4d9ea3521786bc65afaa9150935146d4068c8638bde45e76c9d09462f19da9b", date = "2024-07-21 16:43:01", amount = 0.000082 }, { type = "increase", txid = "598d68ece8df8ca9baf6de361ce8c40bb7956342348d569f219d65e5725b627c", date = "2025-01-28 07:27:07", amount = 0.000006 }, { type = "claim", txid = "a52c5046f3097a8c2bd3b9889df2fb47b104d47a16cc679d3357feec003db753", date = "2025-04-30 14:45:54", amount = 6.9 }]
 solver = { address = "15g7XHM6u921DvvPrgguxYkxDL8ruPGHXZ" }
 
 [[puzzles]]
 bits = 70
-address = "19YZECXj3SxEZMoUeJ1yiPsw8xANe7M7QR"
+address = { value = "19YZECXj3SxEZMoUeJ1yiPsw8xANe7M7QR", kind = "p2pkh", hash160 = "5db8cda53a6a002db10365967d7f85d19e171b10" }
 prize = 0.7
 status = "solved"
 has_pubkey = true
@@ -1070,54 +1001,49 @@ public_key = "0290e6900a58d33393bc1097b5aed31f2e4e7cbd3e5466af958665bc0121248483
 pubkey_format = "compressed"
 solve_date = "2021-06-24 13:22:12"
 start_date = "2015-01-15 18:07:14"
-h160 = "5db8cda53a6a002db10365967d7f85d19e171b10"
 solve_time = 203195698
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.07 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.63 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "482232a3d21b7062d1aaf88a63466fd00eabcb248ae8b92aae82e4bb833afcd7", date = "2019-06-09 17:08:45", amount = 0.7 }]
 solver = { address = "3MpeFYTuwfrxSnUXNmTnY3XTgvhPp5k7vF" }
 
 [[puzzles]]
 bits = 71
-address = "1PWo3JeB9jrGwfHDNpdGK54CRas7fsVzXU"
+address = { value = "1PWo3JeB9jrGwfHDNpdGK54CRas7fsVzXU", kind = "p2pkh", hash160 = "f6f5431d25bbf7b12e8add9af5e3475c44a0a5b8" }
 prize = 7.1002257
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "f6f5431d25bbf7b12e8add9af5e3475c44a0a5b8"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.071 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.639 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.39 }, { type = "increase", txid = "5863063e1fdc2ef84cbb3cea03181faec9e62356a56dc330e7511f67ec50d610", date = "2023-09-25 15:00:17", amount = 0.0000377 }, { type = "increase", txid = "8c75b040d6f335cd1965b205938435baa6bb1b8a2b00038f71d991fd3c7dc0b7", date = "2025-01-28 02:11:50", amount = 0.000006 }, { type = "increase", txid = "b30914607fed925b42a87004ed3b373bd413ac35302d007f28ffbb738c63245e", date = "2025-05-03 09:59:35", amount = 0.00001 }, { type = "increase", txid = "076d820e3100580012a1bcca15987c0d8638cae912f1f4421f05e97cbcdec3b9", date = "2025-05-19 18:56:09", amount = 0.00000001 }, { type = "increase", txid = "e29e1a2200867cbd886a42c8222f0dee1a53b83aa577df5e477d11e3fa9e90cc", date = "2025-05-21 10:01:44", amount = 0.0000888 }, { type = "increase", txid = "72fa88fe21d2cb40c1af0a3022d4e5736ae1c66c6f1afe72463e1791706629c5", date = "2025-07-30 09:32:34", amount = 0.00001 }, { type = "increase", txid = "966c854ce03054ef38f6fdf5ee9a746f03bb34d2ec86101e214d22b2f15b0f0f", date = "2025-08-22 06:05:53", amount = 0.00001767 }, { type = "increase", txid = "dc895ad8b1eb570560326bd0f9c8504304cf03f51c0ce2a753fc4cf29108d24b", date = "2025-09-01 21:47:45", amount = 0.0000071 }, { type = "increase", txid = "c03df28a719a110c50b51e92a0831c28433d6b12180a94e63c4c519b28654e1b", date = "2025-09-02 21:04:37", amount = 0.00000898 }, { type = "increase", txid = "9540c7d4ca42c32cafa643f4dd3f0a4c3beca2fc3c585cd980f474acb6a0267c", date = "2025-09-03 02:48:52", amount = 0.00001 }, { type = "increase", txid = "8aa20456d64c7969d0546cd819437275e78d9bcbc692e93b26129faa98de5cd7", date = "2025-10-07 08:31:00", amount = 0.00000002 }, { type = "increase", txid = "2a18ccf613b076d633099a4da35fd7f72bc3c2a87a2f72a111176dc64271cc11", date = "2025-10-18 00:18:40", amount = 0.00001 }, { type = "increase", txid = "eefa0ac5426b7b6df98d7d85d172d7e42cb714c649ac8fb9629e5571ee7dd78f", date = "2025-12-13 13:35:31", amount = 0.00001941 }, { type = "increase", txid = "a2808acb455f636dc988186219d025e6507bd80640b0056b46583232aee7cfa5", date = "2025-12-14 21:33:17", amount = 0.00000001 }]
 
 [[puzzles]]
 bits = 72
-address = "1JTK7s9YVYywfm5XUH7RNhHJH1LshCaRFR"
+address = { value = "1JTK7s9YVYywfm5XUH7RNhHJH1LshCaRFR", kind = "p2pkh", hash160 = "bf7413e8df4e7a34ce9dc13e2f2648783ec54adb" }
 prize = 7.20014379
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "bf7413e8df4e7a34ce9dc13e2f2648783ec54adb"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.072 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.648 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.48 }, { type = "increase", txid = "7d7dc5027ad971387295921620df609642fb4040a782a6b795be71c1e821ae93", date = "2023-09-25 15:00:17", amount = 0.00003779 }, { type = "increase", txid = "caa959d2e425bd209e5ae73348b247716c71e56b8216aeccf7685733edd08631", date = "2025-01-28 07:27:07", amount = 0.000006 }, { type = "increase", txid = "4b7c35b7ca546193090d58aaf4746f2d5c08fa024bab23f13d8aff3d7a15e030", date = "2025-08-06 12:50:58", amount = 0.0001 }]
 
 [[puzzles]]
 bits = 73
-address = "12VVRNPi4SJqUTsp6FmqDqY5sGosDtysn4"
+address = { value = "12VVRNPi4SJqUTsp6FmqDqY5sGosDtysn4", kind = "p2pkh", hash160 = "105b7f253f0ebd7843adaebbd805c944bfb863e4" }
 prize = 7.30013849
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "105b7f253f0ebd7843adaebbd805c944bfb863e4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.073 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.657 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.57 }, { type = "increase", txid = "cd85afbaa9901d8ede400248713942ff56cfe92806500940624b671f947f508b", date = "2023-09-25 15:00:17", amount = 0.00003777 }, { type = "increase", txid = "d1824b78030f9d670b2e8aaedd1cc9b042951f96a59ad59790a35917bfbdfc54", date = "2025-01-27 14:10:18", amount = 0.000006 }, { type = "increase", txid = "d39bfb73aa05305025c7179d0477201403219556d8d56c7d038c934a08e85e91", date = "2025-11-24 09:49:26", amount = 0.00009472 }]
 
 [[puzzles]]
 bits = 74
-address = "1FWGcVDK3JGzCC3WtkYetULPszMaK2Jksv"
+address = { value = "1FWGcVDK3JGzCC3WtkYetULPszMaK2Jksv", kind = "p2pkh", hash160 = "9f1adb20baeacc38b3f49f3df6906a0e48f2df3d" }
 prize = 7.40004977
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "9f1adb20baeacc38b3f49f3df6906a0e48f2df3d"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.074 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.666 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.66 }, { type = "increase", txid = "49548037c2bc4a22da68dd097be67d98a1e8f47aeaaac6fb92751f755e7d89eb", date = "2023-09-25 15:00:17", amount = 0.00003777 }, { type = "increase", txid = "480f8e96b46315d494fecc06f035e782179e5d9aae7e7417be55c63ff96f06e8", date = "2025-01-28 03:11:55", amount = 0.000006 }, { type = "increase", txid = "89993b4ff06bc6ee94af5b7e78888cbcbdefa38335a53342e4d371f70fa472e6", date = "2025-02-10 06:05:27", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 75
-address = "1J36UjUByGroXcCvmj13U6uwaVv9caEeAt"
+address = { value = "1J36UjUByGroXcCvmj13U6uwaVv9caEeAt", kind = "p2pkh", hash160 = "badf8b0d34289e679ec65c6c61d3a974353be5cf" }
 prize = 0.75
 status = "solved"
 has_pubkey = true
@@ -1126,53 +1052,48 @@ public_key = "03726b574f193e374686d8e12bc6e4142adeb06770e0a2856f5e4ad89f66044755
 pubkey_format = "compressed"
 solve_date = "2019-06-10 21:05:57"
 start_date = "2015-01-15 18:07:14"
-h160 = "badf8b0d34289e679ec65c6c61d3a974353be5cf"
 solve_time = 138855523
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.075 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.675 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "e1a5d5ac5db02801828ec79e6c94fa724525eaa0f6f7fd303dc14a1e9d0f4c64", date = "2019-06-10 21:05:57", amount = 0.75 }]
 
 [[puzzles]]
 bits = 76
-address = "1DJh2eHFYQfACPmrvpyWc8MSTYKh7w9eRF"
+address = { value = "1DJh2eHFYQfACPmrvpyWc8MSTYKh7w9eRF", kind = "p2pkh", hash160 = "86f9fea5cdecf033161dd2f8f8560768ae0a6d14" }
 prize = 7.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "86f9fea5cdecf033161dd2f8f8560768ae0a6d14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.076 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.684 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.84 }]
 
 [[puzzles]]
 bits = 77
-address = "1Bxk4CQdqL9p22JEtDfdXMsng1XacifUtE"
+address = { value = "1Bxk4CQdqL9p22JEtDfdXMsng1XacifUtE", kind = "p2pkh", hash160 = "783c138ac81f6a52398564bb17455576e8525b29" }
 prize = 7.70002426
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "783c138ac81f6a52398564bb17455576e8525b29"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.077 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.693 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 6.93 }, { type = "increase", txid = "8c161394a9cd1f201b0f6d4898cb5cfdff9399f618eee6c1ddf1b76b56e96e71", date = "2023-11-29 09:47:58", amount = 0.00001826 }, { type = "increase", txid = "599bfd6ded754b082dcff0eec969a436ffa9cc888ac515dfe2d5ad4fa96f287f", date = "2025-01-27 18:29:28", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 78
-address = "15qF6X51huDjqTmF9BJgxXdt1xcj46Jmhb"
+address = { value = "15qF6X51huDjqTmF9BJgxXdt1xcj46Jmhb", kind = "p2pkh", hash160 = "35003c3ef8759c92092f8488fca59a042859018c" }
 prize = 7.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "35003c3ef8759c92092f8488fca59a042859018c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.078 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.702 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.02 }]
 
 [[puzzles]]
 bits = 79
-address = "1ARk8HWJMn8js8tQmGUJeQHjSE7KRkn2t8"
+address = { value = "1ARk8HWJMn8js8tQmGUJeQHjSE7KRkn2t8", kind = "p2pkh", hash160 = "67671d5490c272e3ab7ddd34030d587738df33da" }
 prize = 7.9
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "67671d5490c272e3ab7ddd34030d587738df33da"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.079 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.711 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.11 }]
 
 [[puzzles]]
 bits = 80
-address = "1BCf6rHUW6m3iH2ptsvnjgLruAiPQQepLe"
+address = { value = "1BCf6rHUW6m3iH2ptsvnjgLruAiPQQepLe", kind = "p2pkh", hash160 = "6fe5a36eef0684af0b91f3b6cfc972d68c4f6fab" }
 prize = 0.8
 status = "solved"
 has_pubkey = true
@@ -1181,53 +1102,48 @@ public_key = "037e1238f7b1ce757df94faa9a2eb261bf0aeb9f84dbf81212104e78931c2a19dc
 pubkey_format = "compressed"
 solve_date = "2019-06-11 11:08:53"
 start_date = "2015-01-15 18:07:14"
-h160 = "6fe5a36eef0684af0b91f3b6cfc972d68c4f6fab"
 solve_time = 138906099
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.08 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.72 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "bb05d206d64e20c706a7da14cd49b4f80d0c92995db193428ebda753e578ce79", date = "2019-06-11 11:08:53", amount = 0.8 }]
 
 [[puzzles]]
 bits = 81
-address = "15qsCm78whspNQFydGJQk5rexzxTQopnHZ"
+address = { value = "15qsCm78whspNQFydGJQk5rexzxTQopnHZ", kind = "p2pkh", hash160 = "351e605fac813965951ba433b7c2956bf8ad95ce" }
 prize = 8.100015
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "351e605fac813965951ba433b7c2956bf8ad95ce"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.081 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.729 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.29 }, { type = "increase", txid = "3f83b6358b828308e0e64bca18b727c0169636519ecb6643118c9a68d302b9e2", date = "2025-10-14 12:07:24", amount = 0.000015 }]
 
 [[puzzles]]
 bits = 82
-address = "13zYrYhhJxp6Ui1VV7pqa5WDhNWM45ARAC"
+address = { value = "13zYrYhhJxp6Ui1VV7pqa5WDhNWM45ARAC", kind = "p2pkh", hash160 = "20d28d4e87543947c7e4913bcdceaa16e2f8f061" }
 prize = 8.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "20d28d4e87543947c7e4913bcdceaa16e2f8f061"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.082 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.738 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.38 }]
 
 [[puzzles]]
 bits = 83
-address = "14MdEb4eFcT3MVG5sPFG4jGLuHJSnt1Dk2"
+address = { value = "14MdEb4eFcT3MVG5sPFG4jGLuHJSnt1Dk2", kind = "p2pkh", hash160 = "24cef184714bbd030833904f5265c9c3e12a95a2" }
 prize = 8.30002046
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "24cef184714bbd030833904f5265c9c3e12a95a2"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.083 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.747 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.47 }, { type = "increase", txid = "cead5b26ed54835eeb0ac603c983a9c052512eb5d2655e6bfb60e6a8e3fb74d9", date = "2024-12-05 00:52:40", amount = 0.00000546 }, { type = "increase", txid = "2d87bb6d81ae091a0c07a69131c404c32b68d55070d913a41263389a1f5a244b", date = "2025-10-28 12:50:52", amount = 0.000015 }]
 
 [[puzzles]]
 bits = 84
-address = "1CMq3SvFcVEcpLMuuH8PUcNiqsK1oicG2D"
+address = { value = "1CMq3SvFcVEcpLMuuH8PUcNiqsK1oicG2D", kind = "p2pkh", hash160 = "7c99ce73e19f9fbfcce4825ae88261e2b0b0b040" }
 prize = 8.400015
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7c99ce73e19f9fbfcce4825ae88261e2b0b0b040"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.084 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.756 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.56 }, { type = "increase", txid = "99e69ed74aa55f1f92e946909dd2f7e7b488721e3b82aee27fe82f30aef47d0e", date = "2025-10-28 12:03:12", amount = 0.000015 }]
 
 [[puzzles]]
 bits = 85
-address = "1Kh22PvXERd2xpTQk3ur6pPEqFeckCJfAr"
+address = { value = "1Kh22PvXERd2xpTQk3ur6pPEqFeckCJfAr", kind = "p2pkh", hash160 = "cd03c1e6268ce9b89e3c3eeab8d0f1b6e8cac281" }
 prize = 0.85
 status = "solved"
 has_pubkey = true
@@ -1236,53 +1152,48 @@ public_key = "0329c4574a4fd8c810b7e42a4b398882b381bcd85e40c6883712912d167c83e73a
 pubkey_format = "compressed"
 solve_date = "2019-06-17 00:09:39"
 start_date = "2015-01-15 18:07:14"
-h160 = "cd03c1e6268ce9b89e3c3eeab8d0f1b6e8cac281"
 solve_time = 139384945
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.085 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.765 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "bb26e67de6f1b67de29155b6fcd51aa459382803d9b3142091b0373abccc9f81", date = "2019-06-17 00:09:39", amount = 0.85 }]
 
 [[puzzles]]
 bits = 86
-address = "1K3x5L6G57Y494fDqBfrojD28UJv4s5JcK"
+address = { value = "1K3x5L6G57Y494fDqBfrojD28UJv4s5JcK", kind = "p2pkh", hash160 = "c60111ed3d63b49665747b0e31eb382da5193535" }
 prize = 8.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "c60111ed3d63b49665747b0e31eb382da5193535"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.086 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.774 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.74 }]
 
 [[puzzles]]
 bits = 87
-address = "1PxH3K1Shdjb7gSEoTX7UPDZ6SH4qGPrvq"
+address = { value = "1PxH3K1Shdjb7gSEoTX7UPDZ6SH4qGPrvq", kind = "p2pkh", hash160 = "fbc708d671c03e26661b9c08f77598a529858b5e" }
 prize = 8.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "fbc708d671c03e26661b9c08f77598a529858b5e"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.087 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.783 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.83 }]
 
 [[puzzles]]
 bits = 88
-address = "16AbnZjZZipwHMkYKBSfswGWKDmXHjEpSf"
+address = { value = "16AbnZjZZipwHMkYKBSfswGWKDmXHjEpSf", kind = "p2pkh", hash160 = "38a968fdfb457654c51bcfc4f9174d6ee487bb41" }
 prize = 8.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "38a968fdfb457654c51bcfc4f9174d6ee487bb41"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.088 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.792 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 7.92 }]
 
 [[puzzles]]
 bits = 89
-address = "19QciEHbGVNY4hrhfKXmcBBCrJSBZ6TaVt"
+address = { value = "19QciEHbGVNY4hrhfKXmcBBCrJSBZ6TaVt", kind = "p2pkh", hash160 = "5c3862203d1e44ab3af441503e22db97b1c5097e" }
 prize = 8.9
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "5c3862203d1e44ab3af441503e22db97b1c5097e"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.089 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.801 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.01 }]
 
 [[puzzles]]
 bits = 90
-address = "1L12FHH2FHjvTviyanuiFVfmzCy46RRATU"
+address = { value = "1L12FHH2FHjvTviyanuiFVfmzCy46RRATU", kind = "p2pkh", hash160 = "d06b6e206691295ec345782d7ea0686969d8674b" }
 prize = 0.9
 status = "solved"
 has_pubkey = true
@@ -1291,53 +1202,48 @@ public_key = "035c38bd9ae4b10e8a250857006f3cfd98ab15a6196d9f4dfd25bc7ecc77d788d5
 pubkey_format = "compressed"
 solve_date = "2019-10-05 20:58:50"
 start_date = "2015-01-15 18:07:14"
-h160 = "d06b6e206691295ec345782d7ea0686969d8674b"
 solve_time = 148963896
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.09 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.81 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "93037990e3739041347cb63563731c0a302d856e21c2c46b7ff491a2ff1ba9fe", date = "2019-07-01 18:09:22", amount = 0.9 }]
 
 [[puzzles]]
 bits = 91
-address = "1EzVHtmbN4fs4MiNk3ppEnKKhsmXYJ4s74"
+address = { value = "1EzVHtmbN4fs4MiNk3ppEnKKhsmXYJ4s74", kind = "p2pkh", hash160 = "9978f61b92d16c5f1a463a0995df70da1f7a7d2a" }
 prize = 9.1
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "9978f61b92d16c5f1a463a0995df70da1f7a7d2a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.091 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.819 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.19 }]
 
 [[puzzles]]
 bits = 92
-address = "1AE8NzzgKE7Yhz7BWtAcAAxiFMbPo82NB5"
+address = { value = "1AE8NzzgKE7Yhz7BWtAcAAxiFMbPo82NB5", kind = "p2pkh", hash160 = "6534b31208fe6e100d29f9c9c75aac8bf06fbb38" }
 prize = 9.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "6534b31208fe6e100d29f9c9c75aac8bf06fbb38"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.092 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.828 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.28 }]
 
 [[puzzles]]
 bits = 93
-address = "17Q7tuG2JwFFU9rXVj3uZqRtioH3mx2Jad"
+address = { value = "17Q7tuG2JwFFU9rXVj3uZqRtioH3mx2Jad", kind = "p2pkh", hash160 = "463013cd41279f2fd0c31d0a16db3972bfffac8d" }
 prize = 9.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "463013cd41279f2fd0c31d0a16db3972bfffac8d"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.093 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.837 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.37 }]
 
 [[puzzles]]
 bits = 94
-address = "1K6xGMUbs6ZTXBnhw1pippqwK6wjBWtNpL"
+address = { value = "1K6xGMUbs6ZTXBnhw1pippqwK6wjBWtNpL", kind = "p2pkh", hash160 = "c6927a00970d0165327d0a6db7950f05720c295c" }
 prize = 9.4
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "c6927a00970d0165327d0a6db7950f05720c295c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.094 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.846 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.46 }]
 
 [[puzzles]]
 bits = 95
-address = "19eVSDuizydXxhohGh8Ki9WY9KsHdSwoQC"
+address = { value = "19eVSDuizydXxhohGh8Ki9WY9KsHdSwoQC", kind = "p2pkh", hash160 = "5ed822125365274262191d2b77e88d436dd56d88" }
 prize = 0.95
 status = "solved"
 has_pubkey = true
@@ -1346,53 +1252,48 @@ public_key = "02967a5905d6f3b420959a02789f96ab4c3223a2c4d2762f817b7895c5bc88a045
 pubkey_format = "compressed"
 solve_date = "2025-08-25 14:12:55"
 start_date = "2015-01-15 18:07:14"
-h160 = "5ed822125365274262191d2b77e88d436dd56d88"
 solve_time = 334785941
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.095 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.855 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "2b46d8d754b712c0c481185f07fa7b11100fe48f807069fc2e0779735d81c99e", date = "2019-07-06 06:53:41", amount = 0.95 }]
 
 [[puzzles]]
 bits = 96
-address = "15ANYzzCp5BFHcCnVFzXqyibpzgPLWaD8b"
+address = { value = "15ANYzzCp5BFHcCnVFzXqyibpzgPLWaD8b", kind = "p2pkh", hash160 = "2da63cbd251d23c7b633cb287c09e6cf888b3fe4" }
 prize = 9.600006
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "2da63cbd251d23c7b633cb287c09e6cf888b3fe4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.096 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.864 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.64 }, { type = "increase", txid = "4fc70c0b7d7ad5a07e8841eb3e6e724bac7b94c59b86b8844c2e13575a2b8901", date = "2025-04-07 14:14:43", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 97
-address = "18ywPwj39nGjqBrQJSzZVq2izR12MDpDr8"
+address = { value = "18ywPwj39nGjqBrQJSzZVq2izR12MDpDr8", kind = "p2pkh", hash160 = "578d94dc6f40fff35f91f6fba9b71c46b361dff2" }
 prize = 9.70002613
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "578d94dc6f40fff35f91f6fba9b71c46b361dff2"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.097 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.873 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.73 }, { type = "increase", txid = "41ea4b706003301ad5481e7a15125fa056a0179aa2daf774477b4afc44415194", date = "2025-10-23 08:05:49", amount = 0.00002613 }]
 
 [[puzzles]]
 bits = 98
-address = "1CaBVPrwUxbQYYswu32w7Mj4HR4maNoJSX"
+address = { value = "1CaBVPrwUxbQYYswu32w7Mj4HR4maNoJSX", kind = "p2pkh", hash160 = "7eefddd979a1d6bb6f29757a1f463579770ba566" }
 prize = 9.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7eefddd979a1d6bb6f29757a1f463579770ba566"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.098 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.882 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.82 }]
 
 [[puzzles]]
 bits = 99
-address = "1JWnE6p6UN7ZJBN7TtcbNDoRcjFtuDWoNL"
+address = { value = "1JWnE6p6UN7ZJBN7TtcbNDoRcjFtuDWoNL", kind = "p2pkh", hash160 = "c01bf430a97cbcdaedddba87ef4ea21c456cebdb" }
 prize = 9.91257338
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "c01bf430a97cbcdaedddba87ef4ea21c456cebdb"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.099 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.891 }, { type = "increase", txid = "cc3fb8769d4e928dab2f5ddbb65838ada2bc0d4e33cfd933d8a1a09fc4b6fa7e", date = "2022-12-13 23:51:04", amount = 0.00094933 }, { type = "increase", txid = "17324bb2efbfa6826d6923f580751f28d8c5297f262a764e27d62bc4e9ba5b68", date = "2023-01-23 02:46:23", amount = 0.00189209 }, { type = "increase", txid = "7de20a1b73abad37d2af5ced79297f33b38f724ef4477901765ddbfb740cc834", date = "2023-02-16 02:52:13", amount = 0.00069016 }, { type = "increase", txid = "b425616ced3391587a8f778c36a949336c0717c62db71953a658bc16a8c7f748", date = "2023-02-16 13:39:42", amount = 0.0090418 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 8.91 }]
 
 [[puzzles]]
 bits = 100
-address = "1KCgMv8fo2TPBpddVi9jqmMmcne9uSNJ5F"
+address = { value = "1KCgMv8fo2TPBpddVi9jqmMmcne9uSNJ5F", kind = "p2pkh", hash160 = "c7a7b23f6bd98b8aaf527beb724dda9460b1bc6e" }
 prize = 1.0
 status = "solved"
 has_pubkey = true
@@ -1401,53 +1302,48 @@ public_key = "03d2063d40402f030d4cc71331468827aa41a8a09bd6fd801ba77fb64f8e67e617
 pubkey_format = "compressed"
 solve_date = "2025-07-04 18:44:54"
 start_date = "2015-01-15 18:07:14"
-h160 = "c7a7b23f6bd98b8aaf527beb724dda9460b1bc6e"
 solve_time = 330309460
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.1 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.9 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "d4087636f7c54d382164e4cd9548a1bad6c603664268f74537b6aed8a6371704", date = "2019-07-08 04:57:04", amount = 1.0 }]
 
 [[puzzles]]
 bits = 101
-address = "1CKCVdbDJasYmhswB6HKZHEAnNaDpK7W4n"
+address = { value = "1CKCVdbDJasYmhswB6HKZHEAnNaDpK7W4n", kind = "p2pkh", hash160 = "7c1a77205c03b9909663b2034faa0b544e6bc96b" }
 prize = 10.1
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7c1a77205c03b9909663b2034faa0b544e6bc96b"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.101 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.909 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.09 }]
 
 [[puzzles]]
 bits = 102
-address = "1PXv28YxmYMaB8zxrKeZBW8dt2HK7RkRPX"
+address = { value = "1PXv28YxmYMaB8zxrKeZBW8dt2HK7RkRPX", kind = "p2pkh", hash160 = "f72b812932f6d7102233971d65cec0a22b89e136" }
 prize = 10.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "f72b812932f6d7102233971d65cec0a22b89e136"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.102 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.918 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.18 }]
 
 [[puzzles]]
 bits = 103
-address = "1AcAmB6jmtU6AiEcXkmiNE9TNVPsj9DULf"
+address = { value = "1AcAmB6jmtU6AiEcXkmiNE9TNVPsj9DULf", kind = "p2pkh", hash160 = "695fd6dcf33f47166b25de968b2932b351b0afc4" }
 prize = 10.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "695fd6dcf33f47166b25de968b2932b351b0afc4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.103 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.927 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.27 }]
 
 [[puzzles]]
 bits = 104
-address = "1EQJvpsmhazYCcKX5Au6AZmZKRnzarMVZu"
+address = { value = "1EQJvpsmhazYCcKX5Au6AZmZKRnzarMVZu", kind = "p2pkh", hash160 = "93022af9a38f3ebb0c3f15dd1c83f8fadaf64e74" }
 prize = 10.400016
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "93022af9a38f3ebb0c3f15dd1c83f8fadaf64e74"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.104 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.936 }, { type = "increase", txid = "a83225cc95582f66fb42d285c64c52a6a6b6b2cec715e2429c67e3f3243071d0", date = "2023-02-02 21:40:21", amount = 0.000006 }, { type = "increase", txid = "123c8804d6d28510c7c11a1b56ea36b4caa1e86f7e6edaf64ee65d16bf9fad67", date = "2023-02-04 01:25:54", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.36 }]
 
 [[puzzles]]
 bits = 105
-address = "1CMjscKB3QW7SDyQ4c3C3DEUHiHRhiZVib"
+address = { value = "1CMjscKB3QW7SDyQ4c3C3DEUHiHRhiZVib", kind = "p2pkh", hash160 = "7c957db6fdd0733bb83bc6d6d747711263ba50b0" }
 prize = 1.05
 status = "solved"
 has_pubkey = true
@@ -1456,53 +1352,48 @@ public_key = "03bcf7ce887ffca5e62c9cabbdb7ffa71dc183c52c04ff4ee5ee82e0c55c39d77b
 pubkey_format = "compressed"
 solve_date = "2019-09-23 01:29:47"
 start_date = "2015-01-15 18:07:14"
-h160 = "7c957db6fdd0733bb83bc6d6d747711263ba50b0"
 solve_time = 147856953
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.105 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.945 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "1f31aa69f56972c08e70da07c92903949fb0f4cd6b02462c1d0de81130113f14", date = "2019-09-23 01:29:47", amount = 1.05 }]
 
 [[puzzles]]
 bits = 106
-address = "18KsfuHuzQaBTNLASyj15hy4LuqPUo1FNB"
+address = { value = "18KsfuHuzQaBTNLASyj15hy4LuqPUo1FNB", kind = "p2pkh", hash160 = "505aaa63a5e209dfb90cee683a8e227a8c278e47" }
 prize = 10.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "505aaa63a5e209dfb90cee683a8e227a8c278e47"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.106 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.954 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.54 }]
 
 [[puzzles]]
 bits = 107
-address = "15EJFC5ZTs9nhsdvSUeBXjLAuYq3SWaxTc"
+address = { value = "15EJFC5ZTs9nhsdvSUeBXjLAuYq3SWaxTc", kind = "p2pkh", hash160 = "2e644e46b042ffa86da35c54d7275f1abe6d4911" }
 prize = 10.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "2e644e46b042ffa86da35c54d7275f1abe6d4911"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.107 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.963 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.63 }]
 
 [[puzzles]]
 bits = 108
-address = "1HB1iKUqeffnVsvQsbpC6dNi1XKbyNuqao"
+address = { value = "1HB1iKUqeffnVsvQsbpC6dNi1XKbyNuqao", kind = "p2pkh", hash160 = "b166c44f12c7fc565f37ff6288ee64e0f0ec9a0b" }
 prize = 10.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "b166c44f12c7fc565f37ff6288ee64e0f0ec9a0b"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.108 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.972 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.72 }]
 
 [[puzzles]]
 bits = 109
-address = "1GvgAXVCbA8FBjXfWiAms4ytFeJcKsoyhL"
+address = { value = "1GvgAXVCbA8FBjXfWiAms4ytFeJcKsoyhL", kind = "p2pkh", hash160 = "aeb0a0197442d4ade8ef41442d557b0e22b85ac0" }
 prize = 10.900105
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "aeb0a0197442d4ade8ef41442d557b0e22b85ac0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.109 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.981 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.81 }, { type = "increase", txid = "5478d5178f0d80ad412b5f5de7d28bb1f31ec1d0eecd0c74f4447bad6d31fc3d", date = "2025-11-21 18:58:34", amount = 0.000105 }]
 
 [[puzzles]]
 bits = 110
-address = "12JzYkkN76xkwvcPT6AWKZtGX6w2LAgsJg"
+address = { value = "12JzYkkN76xkwvcPT6AWKZtGX6w2LAgsJg", kind = "p2pkh", hash160 = "0e5f3c406397442996825fd395543514fd06f207" }
 prize = 1.1
 status = "solved"
 has_pubkey = true
@@ -1511,53 +1402,48 @@ public_key = "0309976ba5570966bf889196b7fdf5a0f9a1e9ab340556ec29f8bb60599616167d
 pubkey_format = "compressed"
 solve_date = "2020-05-30 20:30:37"
 start_date = "2015-01-15 18:07:14"
-h160 = "0e5f3c406397442996825fd395543514fd06f207"
 solve_time = 169525403
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.11 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.99 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "ed53ace1d284e1b9c5b2058fd296ee7d5be43efd6ce87d0a03adfe039c171e28", date = "2019-10-31 00:45:03", amount = 0.000007 }, { type = "increase", txid = "03217c5fa3ab110901d53c998d8ea67e6d9b57f957815a9bd973c7d7fb7ed0f0", date = "2019-11-11 19:37:03", amount = 0.00000997 }, { type = "increase", txid = "b0a92ea5ae2a58bdf7c6252edc10e6a5a0f1cc4a05455792e4984ca84d2607f4", date = "2019-11-11 20:54:30", amount = 0.00001636 }, { type = "claim", txid = "8978a26d73ed11fec60d88f5cdb5f6d762c8e4fdb1dcae924ba5b06eb7fda456", date = "2020-05-30 20:04:06", amount = 1.10003333 }]
 
 [[puzzles]]
 bits = 111
-address = "1824ZJQ7nKJ9QFTRBqn7z7dHV5EGpzUpH3"
+address = { value = "1824ZJQ7nKJ9QFTRBqn7z7dHV5EGpzUpH3", kind = "p2pkh", hash160 = "4cfc43fe12a330c8164251e38c0c0c3c84cf86f6" }
 prize = 11.1001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "4cfc43fe12a330c8164251e38c0c0c3c84cf86f6"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.111 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.999 }, { type = "increase", txid = "0278037d401dd66fab16d5688a203bc776a344232ae107fee0113be1f2d617cd", date = "2022-03-20 22:30:43", amount = 0.0001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 9.99 }]
 
 [[puzzles]]
 bits = 112
-address = "18A7NA9FTsnJxWgkoFfPAFbQzuQxpRtCos"
+address = { value = "18A7NA9FTsnJxWgkoFfPAFbQzuQxpRtCos", kind = "p2pkh", hash160 = "4e81efec43c5195aeca0e3877664330418b8e48e" }
 prize = 11.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "4e81efec43c5195aeca0e3877664330418b8e48e"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.112 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.008 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.08 }]
 
 [[puzzles]]
 bits = 113
-address = "1NeGn21dUDDeqFQ63xb2SpgUuXuBLA4WT4"
+address = { value = "1NeGn21dUDDeqFQ63xb2SpgUuXuBLA4WT4", kind = "p2pkh", hash160 = "ed673389e4b12925316f9166d56d701829e53cf8" }
 prize = 11.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "ed673389e4b12925316f9166d56d701829e53cf8"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.113 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.017 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.17 }]
 
 [[puzzles]]
 bits = 114
-address = "174SNxfqpdMGYy5YQcfLbSTK3MRNZEePoy"
+address = { value = "174SNxfqpdMGYy5YQcfLbSTK3MRNZEePoy", kind = "p2pkh", hash160 = "42773005f9594cd16b10985d428418acb7f352ec" }
 prize = 11.4
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "42773005f9594cd16b10985d428418acb7f352ec"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.114 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.026 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.26 }]
 
 [[puzzles]]
 bits = 115
-address = "1NLbHuJebVwUZ1XqDjsAyfTRUPwDQbemfv"
+address = { value = "1NLbHuJebVwUZ1XqDjsAyfTRUPwDQbemfv", kind = "p2pkh", hash160 = "ea0f2b7576bd098921fce9bfebe37f6383e639a4" }
 prize = 1.15
 status = "solved"
 has_pubkey = true
@@ -1566,53 +1452,48 @@ public_key = "0248d313b0398d4923cdca73b8cfa6532b91b96703902fc8b32fd438a3b7cd7f55
 pubkey_format = "compressed"
 solve_date = "2020-06-16 07:33:42"
 start_date = "2015-01-15 18:07:14"
-h160 = "ea0f2b7576bd098921fce9bfebe37f6383e639a4"
 solve_time = 170947588
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.115 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.035 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "15df42c8d957ca66700a7c6455da76c5d88ee847b47819447527f0985827b1ce", date = "2020-06-16 07:33:42", amount = 1.15 }]
 
 [[puzzles]]
 bits = 116
-address = "1MnJ6hdhvK37VLmqcdEwqC3iFxyWH2PHUV"
+address = { value = "1MnJ6hdhvK37VLmqcdEwqC3iFxyWH2PHUV", kind = "p2pkh", hash160 = "e3f381c34a20da049779b44cae0417c7fb2898d0" }
 prize = 11.6000121
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "e3f381c34a20da049779b44cae0417c7fb2898d0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.116 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.044 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.44 }, { type = "increase", txid = "0e10fc1cc2288bb2df6dc15a29827aaa71724e1f93bc29b9bc7b9882fde97645", date = "2025-03-16 03:24:47", amount = 0.0000121 }]
 
 [[puzzles]]
 bits = 117
-address = "1KNRfGWw7Q9Rmwsc6NT5zsdvEb9M2Wkj5Z"
+address = { value = "1KNRfGWw7Q9Rmwsc6NT5zsdvEb9M2Wkj5Z", kind = "p2pkh", hash160 = "c97f9591e28687be1c4d972e25be7c372a3221b4" }
 prize = 11.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "c97f9591e28687be1c4d972e25be7c372a3221b4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.117 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.053 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.53 }]
 
 [[puzzles]]
 bits = 118
-address = "1PJZPzvGX19a7twf5HyD2VvNiPdHLzm9F6"
+address = { value = "1PJZPzvGX19a7twf5HyD2VvNiPdHLzm9F6", kind = "p2pkh", hash160 = "f4a4e1c11a5bbbd2fc139d221825407c66e0b8b4" }
 prize = 11.80000661
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "f4a4e1c11a5bbbd2fc139d221825407c66e0b8b4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.118 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.062 }, { type = "increase", txid = "8c389a5038ef933ad14b81781971e91679cbd563c4ee29c1efa7a9e629ab2d8b", date = "2021-10-05 07:06:59", amount = 0.00000661 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.62 }]
 
 [[puzzles]]
 bits = 119
-address = "1GuBBhf61rnvRe4K8zu8vdQB3kHzwFqSy7"
+address = { value = "1GuBBhf61rnvRe4K8zu8vdQB3kHzwFqSy7", kind = "p2pkh", hash160 = "ae6804b35c82f47f8b0a42d8c5e514fe5ef0a883" }
 prize = 11.9
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "ae6804b35c82f47f8b0a42d8c5e514fe5ef0a883"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.119 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.071 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.71 }]
 
 [[puzzles]]
 bits = 120
-address = "17s2b9ksz5y7abUm92cHwG8jEPCzK3dLnT"
+address = { value = "17s2b9ksz5y7abUm92cHwG8jEPCzK3dLnT", kind = "p2pkh", hash160 = "4b46e10a541aeec6be3fac709c256fb7da69308e" }
 prize = 1.2
 status = "solved"
 has_pubkey = true
@@ -1621,54 +1502,49 @@ public_key = "02ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a2630
 pubkey_format = "compressed"
 solve_date = "2023-02-27 09:40:55"
 start_date = "2015-01-15 18:07:14"
-h160 = "4b46e10a541aeec6be3fac709c256fb7da69308e"
 solve_time = 256145621
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.12 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.08 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "claim", txid = "9628d6d234b57075709a74215bfe2869b4d80b8ada11dd7be1030541ff8a0a53", date = "2023-02-27 09:40:55", amount = 1.2 }]
 solver = { address = "1Prestige1zSYorBdz94KA2UbJW3hYLTn4" }
 
 [[puzzles]]
 bits = 121
-address = "1GDSuiThEV64c166LUFC9uDcVdGjqkxKyh"
+address = { value = "1GDSuiThEV64c166LUFC9uDcVdGjqkxKyh", kind = "p2pkh", hash160 = "a6e4818537e42f7b3f021daa810367dad4dda16f" }
 prize = 12.1
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "a6e4818537e42f7b3f021daa810367dad4dda16f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.121 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.089 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.89 }]
 
 [[puzzles]]
 bits = 122
-address = "1Me3ASYt5JCTAK2XaC32RMeH34PdprrfDx"
+address = { value = "1Me3ASYt5JCTAK2XaC32RMeH34PdprrfDx", kind = "p2pkh", hash160 = "e263b62ea294b9650615a13b926e75944c823990" }
 prize = 12.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "e263b62ea294b9650615a13b926e75944c823990"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.122 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.098 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 10.98 }]
 
 [[puzzles]]
 bits = 123
-address = "1CdufMQL892A69KXgv6UNBD17ywWqYpKut"
+address = { value = "1CdufMQL892A69KXgv6UNBD17ywWqYpKut", kind = "p2pkh", hash160 = "7fa4515066ba6905f894b2078f9af7b1379169cf" }
 prize = 12.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7fa4515066ba6905f894b2078f9af7b1379169cf"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.123 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.107 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.07 }]
 
 [[puzzles]]
 bits = 124
-address = "1BkkGsX9ZM6iwL3zbqs7HWBV7SvosR6m8N"
+address = { value = "1BkkGsX9ZM6iwL3zbqs7HWBV7SvosR6m8N", kind = "p2pkh", hash160 = "75f74467ce7214f1767406d5ed12012aa523c48e" }
 prize = 12.4
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "75f74467ce7214f1767406d5ed12012aa523c48e"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.124 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.116 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.16 }]
 
 [[puzzles]]
 bits = 125
-address = "1PXAyUB8ZoH3WD8n5zoAthYjN15yN5CVq5"
+address = { value = "1PXAyUB8ZoH3WD8n5zoAthYjN15yN5CVq5", kind = "p2pkh", hash160 = "f7079256aa027dc437cbb539f955472416725fc8" }
 prize = 12.5
 status = "solved"
 has_pubkey = true
@@ -1677,54 +1553,49 @@ public_key = "0233709eb11e0d4439a729f21c2c443dedb727528229713f0065721ba8fa46f00e
 pubkey_format = "compressed"
 solve_date = "2024-11-15 05:52:34"
 start_date = "2015-01-15 18:07:14"
-h160 = "f7079256aa027dc437cbb539f955472416725fc8"
 solve_time = 310304720
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.125 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.125 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.25 }, { type = "claim", txid = "25427dc1fa67f259601750d5fbb98427a51d8b319d179557030ff3c4cb66af7e", date = "2023-07-09 10:24:07", amount = 12.5 }]
 solver = { address = "1Prestige1zSYorBdz94KA2UbJW3hYLTn4" }
 
 [[puzzles]]
 bits = 126
-address = "1AWCLZAjKbV1P7AHvaPNCKiB7ZWVDMxFiz"
+address = { value = "1AWCLZAjKbV1P7AHvaPNCKiB7ZWVDMxFiz", kind = "p2pkh", hash160 = "683ea8a1ef06eada90556017d44323b5c04e00f1" }
 prize = 12.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "683ea8a1ef06eada90556017d44323b5c04e00f1"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.126 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.134 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.34 }]
 
 [[puzzles]]
 bits = 127
-address = "1G6EFyBRU86sThN3SSt3GrHu1sA7w7nzi4"
+address = { value = "1G6EFyBRU86sThN3SSt3GrHu1sA7w7nzi4", kind = "p2pkh", hash160 = "a58708aa98ad35c889bb36d8049bf9e9cacfd02a" }
 prize = 12.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "a58708aa98ad35c889bb36d8049bf9e9cacfd02a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.127 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.143 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.43 }]
 
 [[puzzles]]
 bits = 128
-address = "1MZ2L1gFrCtkkn6DnTT2e4PFUTHw9gNwaj"
+address = { value = "1MZ2L1gFrCtkkn6DnTT2e4PFUTHw9gNwaj", kind = "p2pkh", hash160 = "e170ef514689d7230da362a0c121a07723550512" }
 prize = 12.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "e170ef514689d7230da362a0c121a07723550512"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.128 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.152 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.52 }]
 
 [[puzzles]]
 bits = 129
-address = "1Hz3uv3nNZzBVMXLGadCucgjiCs5W9vaGz"
+address = { value = "1Hz3uv3nNZzBVMXLGadCucgjiCs5W9vaGz", kind = "p2pkh", hash160 = "ba4c2748360a6b66263e11d1dc8658463ca5ff18" }
 prize = 12.9
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "ba4c2748360a6b66263e11d1dc8658463ca5ff18"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.129 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.161 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.61 }]
 
 [[puzzles]]
 bits = 130
-address = "1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua"
+address = { value = "1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua", kind = "p2pkh", hash160 = "a24922852051a9002ebf4c864a55acb75bb4cf75" }
 prize = 13.0
 status = "solved"
 has_pubkey = true
@@ -1733,1471 +1604,1344 @@ public_key = "03633cbe3ec02b9401c5effa144c5b4d22f87940259634858fc7e59b1c09937852
 pubkey_format = "compressed"
 solve_date = "2024-09-23 08:13:37"
 start_date = "2015-01-15 18:07:14"
-h160 = "a24922852051a9002ebf4c864a55acb75bb4cf75"
 solve_time = 305733983
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.13 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.17 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.7 }, { type = "increase", txid = "6fc3dd6147c26e6458a04de586e24330c70b320ec31a67e968ca3eb2f8d5cc70", date = "2023-12-23 00:22:51", amount = 0.00006 }, { type = "claim", txid = "91ec88f5d6d6cc727e0205d3aa3709fee507df05140d187846cf22aef784621a", date = "2024-09-23 08:13:37", amount = 13.00006 }]
 solver = { address = "1Prestige1zSYorBdz94KA2UbJW3hYLTn4" }
 
 [[puzzles]]
 bits = 131
-address = "16zRPnT8znwq42q7XeMkZUhb1bKqgRogyy"
+address = { value = "16zRPnT8znwq42q7XeMkZUhb1bKqgRogyy", kind = "p2pkh", hash160 = "41b4b36a6c036568972380177eca2916cacd71de" }
 prize = 13.1
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "41b4b36a6c036568972380177eca2916cacd71de"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.131 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.179 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.79 }]
 
 [[puzzles]]
 bits = 132
-address = "1KrU4dHE5WrW8rhWDsTRjR21r8t3dsrS3R"
+address = { value = "1KrU4dHE5WrW8rhWDsTRjR21r8t3dsrS3R", kind = "p2pkh", hash160 = "cecd3ca4319651bd3afd1e23ab66e111ed38d16d" }
 prize = 13.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "cecd3ca4319651bd3afd1e23ab66e111ed38d16d"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.132 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.188 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.88 }]
 
 [[puzzles]]
 bits = 133
-address = "17uDfp5r4n441xkgLFmhNoSW1KWp6xVLD"
+address = { value = "17uDfp5r4n441xkgLFmhNoSW1KWp6xVLD", kind = "p2pkh", hash160 = "014e15e4ea6da460cc7835e262676baa37988e4f" }
 prize = 13.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "014e15e4ea6da460cc7835e262676baa37988e4f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.133 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.197 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 11.97 }]
 
 [[puzzles]]
 bits = 134
-address = "13A3JrvXmvg5w9XGvyyR4JEJqiLz8ZySY3"
+address = { value = "13A3JrvXmvg5w9XGvyyR4JEJqiLz8ZySY3", kind = "p2pkh", hash160 = "17a5ebfaf62e73f149e33ba674836801f13a80b9" }
 prize = 13.4
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "17a5ebfaf62e73f149e33ba674836801f13a80b9"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.134 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.206 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.06 }]
 
 [[puzzles]]
 bits = 135
-address = "16RGFo6hjq9ym6Pj7N5H7L1NR1rVPJyw2v"
+address = { value = "16RGFo6hjq9ym6Pj7N5H7L1NR1rVPJyw2v", kind = "p2pkh", hash160 = "3b6f58a75a54bfd85d1bc6c51180fdc732992326" }
 prize = 13.50003408
 status = "unsolved"
 has_pubkey = true
 public_key = "02145d2611c823a396ef6712ce0f712f09b9b4f3135e3e0aa3230fb9b6d08d1e16"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3b6f58a75a54bfd85d1bc6c51180fdc732992326"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.135 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.215 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.15 }, { type = "increase", txid = "e876a49f4f04d687b0b227bf554fbf1878289288291d17339413dd287af27c64", date = "2024-10-09 14:58:21", amount = 0.00002208 }, { type = "increase", txid = "32ea2049816f4bc776a2152bff801a32582d75287d0d79b6b4388b5ba7527fb8", date = "2025-01-28 02:11:50", amount = 0.000006 }, { type = "increase", txid = "3f2ec8791ec73c2216bf1dba98d79624c30bc9bf86abc314404eeec87d43f0c0", date = "2025-03-30 01:49:24", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 136
-address = "1UDHPdovvR985NrWSkdWQDEQ1xuRiTALq"
+address = { value = "1UDHPdovvR985NrWSkdWQDEQ1xuRiTALq", kind = "p2pkh", hash160 = "05257be4b57ee43fc09762d5d3a9ad4a6e1a0364" }
 prize = 13.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "05257be4b57ee43fc09762d5d3a9ad4a6e1a0364"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.136 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.224 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.24 }]
 
 [[puzzles]]
 bits = 137
-address = "15nf31J46iLuK1ZkTnqHo7WgN5cARFK3RA"
+address = { value = "15nf31J46iLuK1ZkTnqHo7WgN5cARFK3RA", kind = "p2pkh", hash160 = "3482f8986e13c018692053a784481c63a3554c9c" }
 prize = 13.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "3482f8986e13c018692053a784481c63a3554c9c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.137 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.233 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.33 }]
 
 [[puzzles]]
 bits = 138
-address = "1Ab4vzG6wEQBDNQM1B2bvUz4fqXXdFk2WT"
+address = { value = "1Ab4vzG6wEQBDNQM1B2bvUz4fqXXdFk2WT", kind = "p2pkh", hash160 = "692a8e583866fc9056f5c61a45969fb9d868a08c" }
 prize = 13.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "692a8e583866fc9056f5c61a45969fb9d868a08c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.138 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.242 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.42 }]
 
 [[puzzles]]
 bits = 139
-address = "1Fz63c775VV9fNyj25d9Xfw3YHE6sKCxbt"
+address = { value = "1Fz63c775VV9fNyj25d9Xfw3YHE6sKCxbt", kind = "p2pkh", hash160 = "a45dae9cd5d3fde21e5aa9a95367d107267b3b8a" }
 prize = 13.9
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "a45dae9cd5d3fde21e5aa9a95367d107267b3b8a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.139 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.251 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.51 }]
 
 [[puzzles]]
 bits = 140
-address = "1QKBaU6WAeycb3DbKbLBkX7vJiaS8r42Xo"
+address = { value = "1QKBaU6WAeycb3DbKbLBkX7vJiaS8r42Xo", kind = "p2pkh", hash160 = "ffbb35a7bb9bbe16c1aa2534f7ff11d59c8e3d1a" }
 prize = 14.000016
 status = "unsolved"
 has_pubkey = true
 public_key = "031f6a332d3c5c4f2de2378c012f429cd109ba07d69690c6c701b6bb87860d6640"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "ffbb35a7bb9bbe16c1aa2534f7ff11d59c8e3d1a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.14 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.26 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "d8c38d06fe7ea6adf44c5cc2cbf50083ec9cd8a3fc6c537e8d39db30639e8a77", date = "2022-11-19 17:06:31", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.6 }, { type = "increase", txid = "dd23b1079095ec6821f003b5a1acd5942152f478411157d717c8bddf8f67fb94", date = "2025-01-28 07:26:00", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 141
-address = "1CD91Vm97mLQvXhrnoMChhJx4TP9MaQkJo"
+address = { value = "1CD91Vm97mLQvXhrnoMChhJx4TP9MaQkJo", kind = "p2pkh", hash160 = "7af50f73fd580f1713af3a6f9c5de49643ec6fc6" }
 prize = 14.10014846
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7af50f73fd580f1713af3a6f9c5de49643ec6fc6"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.141 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.269 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.69 }, { type = "increase", txid = "51fd194a442ad0955b0fc4a0f725d50c196c1b09c6c1d64699b8e48c3880a15e", date = "2024-12-11 23:00:49", amount = 0.00005924 }, { type = "increase", txid = "1bfba1dc3d340b4c4b416f9c1e5c5df4c13324e49113624dc2639941043a8fda", date = "2024-12-12 00:52:52", amount = 0.00008922 }]
 
 [[puzzles]]
 bits = 142
-address = "15MnK2jXPqTMURX4xC3h4mAZxyCcaWWEDD"
+address = { value = "15MnK2jXPqTMURX4xC3h4mAZxyCcaWWEDD", kind = "p2pkh", hash160 = "2fcea55e6d027a2ba7c7ebe95eedf47766730fe2" }
 prize = 14.2
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "2fcea55e6d027a2ba7c7ebe95eedf47766730fe2"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.142 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.278 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.78 }]
 
 [[puzzles]]
 bits = 143
-address = "13N66gCzWWHEZBxhVxG18P8wyjEWF9Yoi1"
+address = { value = "13N66gCzWWHEZBxhVxG18P8wyjEWF9Yoi1", kind = "p2pkh", hash160 = "19ed3e03d19ddcedd5fa86543be820b3a7951650" }
 prize = 14.3
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "19ed3e03d19ddcedd5fa86543be820b3a7951650"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.143 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.287 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.87 }]
 
 [[puzzles]]
 bits = 144
-address = "1NevxKDYuDcCh1ZMMi6ftmWwGrZKC6j7Ux"
+address = { value = "1NevxKDYuDcCh1ZMMi6ftmWwGrZKC6j7Ux", kind = "p2pkh", hash160 = "ed87120066e244ff5331d5f8625873d7a3acc39c" }
 prize = 14.4
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "ed87120066e244ff5331d5f8625873d7a3acc39c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.144 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.296 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.96 }]
 
 [[puzzles]]
 bits = 145
-address = "19GpszRNUej5yYqxXoLnbZWKew3KdVLkXg"
+address = { value = "19GpszRNUej5yYqxXoLnbZWKew3KdVLkXg", kind = "p2pkh", hash160 = "5abf369388deb8072741b4eb43ef10fa9388a729" }
 prize = 14.500006
 status = "unsolved"
 has_pubkey = true
 public_key = "03afdda497369e219a2c1c369954a930e4d3740968e5e4352475bcffce3140dae5"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "5abf369388deb8072741b4eb43ef10fa9388a729"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.145 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.305 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.05 }, { type = "increase", txid = "35c62ac2e2118aea9167f918670ea9e60e4c82029da01b33f82756372faa53e7", date = "2025-01-28 03:11:55", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 146
-address = "1M7ipcdYHey2Y5RZM34MBbpugghmjaV89P"
+address = { value = "1M7ipcdYHey2Y5RZM34MBbpugghmjaV89P", kind = "p2pkh", hash160 = "dca7ebfb78ce21884300f133d89244bc4b1b756f" }
 prize = 14.6
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "dca7ebfb78ce21884300f133d89244bc4b1b756f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.146 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.314 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.14 }]
 
 [[puzzles]]
 bits = 147
-address = "18aNhurEAJsw6BAgtANpexk5ob1aGTwSeL"
+address = { value = "18aNhurEAJsw6BAgtANpexk5ob1aGTwSeL", kind = "p2pkh", hash160 = "5318b9d7fcc93873f768725eb68ba2c924bb07ee" }
 prize = 14.7
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "5318b9d7fcc93873f768725eb68ba2c924bb07ee"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.147 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.323 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.23 }]
 
 [[puzzles]]
 bits = 148
-address = "1FwZXt6EpRT7Fkndzv6K4b4DFoT4trbMrV"
+address = { value = "1FwZXt6EpRT7Fkndzv6K4b4DFoT4trbMrV", kind = "p2pkh", hash160 = "a3e3612e586fd206efb8eee6ccd58318e182829a" }
 prize = 14.8
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "a3e3612e586fd206efb8eee6ccd58318e182829a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.148 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.332 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.32 }]
 
 [[puzzles]]
 bits = 149
-address = "1CXvTzR6qv8wJ7eprzUKeWxyGcHwDYP1i2"
+address = { value = "1CXvTzR6qv8wJ7eprzUKeWxyGcHwDYP1i2", kind = "p2pkh", hash160 = "7e827e3b90da24c2a15f7b67e3bbece39955a5d0" }
 prize = 14.90001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "7e827e3b90da24c2a15f7b67e3bbece39955a5d0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.149 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.341 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.41 }]
 
 [[puzzles]]
 bits = 150
-address = "1MUJSJYtGPVGkBCTqGspnxyHahpt5Te8jy"
+address = { value = "1MUJSJYtGPVGkBCTqGspnxyHahpt5Te8jy", kind = "p2pkh", hash160 = "e08c4d3bc9cf2b3e2cb88de2bfaa4fe8c7aa3f24" }
 prize = 15.000016
 status = "unsolved"
 has_pubkey = true
 public_key = "03137807790ea7dc6e97901c2bc87411f45ed74a5629315c4e4b03a0a102250c49"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "e08c4d3bc9cf2b3e2cb88de2bfaa4fe8c7aa3f24"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.15 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.35 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.5 }, { type = "increase", txid = "284ef13f3a81cb301fa1bf570f2cdfeb27d8d93140b9a14950a1a5769ac60071", date = "2025-01-27 14:15:16", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 151
-address = "13Q84TNNvgcL3HJiqQPvyBb9m4hxjS3jkV"
+address = { value = "13Q84TNNvgcL3HJiqQPvyBb9m4hxjS3jkV", kind = "p2pkh", hash160 = "1a4fb632f0de0c53a0a31d57f840a19e56c645ee" }
 prize = 15.10001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "1a4fb632f0de0c53a0a31d57f840a19e56c645ee"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.151 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.359 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.59 }]
 
 [[puzzles]]
 bits = 152
-address = "1LuUHyrQr8PKSvbcY1v1PiuGuqFjWpDumN"
+address = { value = "1LuUHyrQr8PKSvbcY1v1PiuGuqFjWpDumN", kind = "p2pkh", hash160 = "da56cd815fa2f0d6a4ce6d25ed7b1a01d9f9bc6b" }
 prize = 15.20001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "da56cd815fa2f0d6a4ce6d25ed7b1a01d9f9bc6b"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.152 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.368 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.68 }]
 
 [[puzzles]]
 bits = 153
-address = "18192XpzzdDi2K11QVHR7td2HcPS6Qs5vg"
+address = { value = "18192XpzzdDi2K11QVHR7td2HcPS6Qs5vg", kind = "p2pkh", hash160 = "4ccf94a1b0efd63cddeee0ef5eee5ebe720cfcbf" }
 prize = 15.30001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "4ccf94a1b0efd63cddeee0ef5eee5ebe720cfcbf"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.153 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.377 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.77 }]
 
 [[puzzles]]
 bits = 154
-address = "1NgVmsCCJaKLzGyKLFJfVequnFW9ZvnMLN"
+address = { value = "1NgVmsCCJaKLzGyKLFJfVequnFW9ZvnMLN", kind = "p2pkh", hash160 = "edd2e206825fa8949d1304cd82c08d64b222f2eb" }
 prize = 15.40001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "edd2e206825fa8949d1304cd82c08d64b222f2eb"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.154 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.386 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.86 }]
 
 [[puzzles]]
 bits = 155
-address = "1AoeP37TmHdFh8uN72fu9AqgtLrUwcv2wJ"
+address = { value = "1AoeP37TmHdFh8uN72fu9AqgtLrUwcv2wJ", kind = "p2pkh", hash160 = "6b8b7830f73c5bf9e8beb9f161ad82b3bde992e4" }
 prize = 15.500116
 status = "unsolved"
 has_pubkey = true
 public_key = "035cd1854cae45391ca4ec428cc7e6c7d9984424b954209a8eea197b9e364c05f6"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "6b8b7830f73c5bf9e8beb9f161ad82b3bde992e4"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.155 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.395 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.95 }, { type = "increase", txid = "ddf0c3de51e34363c756e5850f4a2fc1b9af8dcb76a2d7f9e61cebc5526e95de", date = "2025-01-28 07:26:42", amount = 0.000006 }, { type = "increase", txid = "21f8ff5f3bd280004239e4b0c4a4e82f2e8919cf91245800656cf2bb7ec25aa0", date = "2025-05-02 13:12:32", amount = 0.0001 }]
 
 [[puzzles]]
 bits = 156
-address = "1FTpAbQa4h8trvhQXjXnmNhqdiGBd1oraE"
+address = { value = "1FTpAbQa4h8trvhQXjXnmNhqdiGBd1oraE", kind = "p2pkh", hash160 = "9ea3f29aaedf7da10b1488934c50a39e271b0b64" }
 prize = 15.60001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "9ea3f29aaedf7da10b1488934c50a39e271b0b64"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.156 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.404 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.04 }]
 
 [[puzzles]]
 bits = 157
-address = "14JHoRAdmJg3XR4RjMDh6Wed6ft6hzbQe9"
+address = { value = "14JHoRAdmJg3XR4RjMDh6Wed6ft6hzbQe9", kind = "p2pkh", hash160 = "242d790e5a168043c76f0539fd894b73ee67b3b3" }
 prize = 15.70001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "242d790e5a168043c76f0539fd894b73ee67b3b3"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.157 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.413 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.13 }]
 
 [[puzzles]]
 bits = 158
-address = "19z6waranEf8CcP8FqNgdwUe1QRxvUNKBG"
+address = { value = "19z6waranEf8CcP8FqNgdwUe1QRxvUNKBG", kind = "p2pkh", hash160 = "628dacebb0faa7f81670e174ca4c8a95a7e37029" }
 prize = 15.80001
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "628dacebb0faa7f81670e174ca4c8a95a7e37029"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.158 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.422 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.22 }]
 
 [[puzzles]]
 bits = 159
-address = "14u4nA5sugaswb6SZgn5av2vuChdMnD9E5"
+address = { value = "14u4nA5sugaswb6SZgn5av2vuChdMnD9E5", kind = "p2pkh", hash160 = "2ac1295b4e54b3f15bb0a99f84018d2082495645" }
 prize = 15.900026
 status = "unsolved"
 has_pubkey = false
 start_date = "2015-01-15 18:07:14"
-h160 = "2ac1295b4e54b3f15bb0a99f84018d2082495645"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.159 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.431 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.31 }, { type = "increase", txid = "a22040a32e5f5772ff9def5c371150e03ac4a5736bad0df527063882f03ac8cc", date = "2024-07-13 19:07:25", amount = 0.00001 }, { type = "increase", txid = "5603c7ee6b025c823009b28e4ccb476e72eec94ef202155cfbc10f5cc94ea697", date = "2025-01-28 07:26:42", amount = 0.000006 }]
 
 [[puzzles]]
 bits = 160
-address = "1NBC8uXJy1GiJ6drkiZa1WuKn51ps7EPTv"
+address = { value = "1NBC8uXJy1GiJ6drkiZa1WuKn51ps7EPTv", kind = "p2pkh", hash160 = "e84818e1bf7f699aa6e28ef9edfb582099099292" }
 prize = 16.00119082
 status = "unsolved"
 has_pubkey = true
 public_key = "02e0a8b039282faf6fe0fd769cfbc4b6b4cf8758ba68220eac420e32b91ddfa673"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "e84818e1bf7f699aa6e28ef9edfb582099099292"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.16 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.44 }, { type = "increase", txid = "336043f3a5f08e4f08dc25bf7ae61aa74d008641a55e4a8e37d2a71a2d0fbd65", date = "2019-02-24 21:48:34", amount = 0.00000793 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "6b2f1287b8e6f9b4394977a2d389313647ef0f004d6ef0f752a03d014a10a021", date = "2022-11-14 13:12:25", amount = 0.000015 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.4 }, { type = "increase", txid = "f28d7dda479bc61ac34fc762226634e51135b6a6609b2a774e1e4495f9f996ed", date = "2023-09-25 15:00:17", amount = 0.00003768 }, { type = "increase", txid = "d864c1a02f3ba7028d4a0723bc64102b04d3afea7e2a114e2d6db515489750ff", date = "2023-10-23 08:45:40", amount = 0.000006 }, { type = "increase", txid = "4cab5e1213071d60d6e452a6b4e9caefbbae44611c3dc2bd757a639a1f85fdd2", date = "2024-06-29 08:18:58", amount = 0.00000821 }, { type = "increase", txid = "9ad34108526a0491386df4055dae20456551288aba2a8893fccdd6842ab29f7e", date = "2024-07-13 16:22:21", amount = 0.0001 }, { type = "increase", txid = "e2e8e1988044d6195dc6f076a9d5810eec4f3493667b536ddec898dcacc10d4f", date = "2024-07-13 19:07:25", amount = 0.00001 }, { type = "increase", txid = "65ef98ecd6392c4add3fd280f322baa252b697a1b1ab240db0876f004a88a405", date = "2025-01-09 18:32:51", amount = 0.000006 }, { type = "increase", txid = "ae3c5d4277175a604a125f7b4461a083ca1a4dcfd5110b4c77ee773dea7a6877", date = "2025-05-02 09:59:40", amount = 0.001 }]
 
 [[puzzles]]
 bits = 161
-address = "1JkqBQcC4tHcb1JfdCH6nrWYwTPGznHANh"
+address = { value = "1JkqBQcC4tHcb1JfdCH6nrWYwTPGznHANh", kind = "p2pkh", hash160 = "c2c43e2b16f53c713bc00307140eaae188413544" }
 prize = 0.161
 status = "swept"
 has_pubkey = true
 public_key = "031dcf49b480cee5f1a7200ea94795a1c7f69e144f11f031123c14c65077823dcb"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "c2c43e2b16f53c713bc00307140eaae188413544"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.161 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.161 }]
 
 [[puzzles]]
 bits = 162
-address = "17DTUTXUcUYEgrr5GhivxYei4Lrs1xMnS2"
+address = { value = "17DTUTXUcUYEgrr5GhivxYei4Lrs1xMnS2", kind = "p2pkh", hash160 = "442bd85a46d4acd7b082c1d731fb13c8474ffa6f" }
 prize = 0.162
 status = "swept"
 has_pubkey = true
 public_key = "03294d33f5e7b98c885ff540fd3f747010999f640d8fdb021f5a13ef3d06c36a58"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "442bd85a46d4acd7b082c1d731fb13c8474ffa6f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.162 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.162 }]
 
 [[puzzles]]
 bits = 163
-address = "1H6e7SLxv6ZUbuAaZpeUdVNfh3cKBWJRmx"
+address = { value = "1H6e7SLxv6ZUbuAaZpeUdVNfh3cKBWJRmx", kind = "p2pkh", hash160 = "b093122f7fb36d11c9f2c80cff2971fba7c9c1ff" }
 prize = 0.163
 status = "swept"
 has_pubkey = true
 public_key = "02ee740ba74efc08bf39d01ccb7e34f50afe2f4677a9e09755e7fe3808e0cbbac9"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "b093122f7fb36d11c9f2c80cff2971fba7c9c1ff"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.163 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.163 }]
 
 [[puzzles]]
 bits = 164
-address = "1LjQKurNtEDgMdqeCoWRFhHp1FPnLU77Q4"
+address = { value = "1LjQKurNtEDgMdqeCoWRFhHp1FPnLU77Q4", kind = "p2pkh", hash160 = "d86f54f73e343d76dd7401639e427d828ba31eab" }
 prize = 0.164
 status = "swept"
 has_pubkey = true
 public_key = "0312163c60548244d6e565bd877b98808b73830c537efde357c8b5f8c623fb2028"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "d86f54f73e343d76dd7401639e427d828ba31eab"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.164 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.164 }]
 
 [[puzzles]]
 bits = 165
-address = "1F7ZjibYug9bLW3YvkkwBZLrhfLtNjgYrX"
+address = { value = "1F7ZjibYug9bLW3YvkkwBZLrhfLtNjgYrX", kind = "p2pkh", hash160 = "9acf9573eb7b4376beca979cfa769f0677cfd949" }
 prize = 0.165
 status = "swept"
 has_pubkey = true
 public_key = "037c6fcde6a2e0fd57ce21bb4352f7bb38859d2af5388b27ebfed107907e060c5c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "9acf9573eb7b4376beca979cfa769f0677cfd949"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.165 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.165 }]
 
 [[puzzles]]
 bits = 166
-address = "12BtvPaamiBCpXmoDrsCxAa1b6hMRnASZ4"
+address = { value = "12BtvPaamiBCpXmoDrsCxAa1b6hMRnASZ4", kind = "p2pkh", hash160 = "0d07a05f7687824fb4dd4a160ddbdc3808655004" }
 prize = 0.166
 status = "swept"
 has_pubkey = true
 public_key = "02b02f753542201387815c4754b66202ef6dc4b3415e4c4cc826d6534394702f50"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "0d07a05f7687824fb4dd4a160ddbdc3808655004"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.166 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.166 }]
 
 [[puzzles]]
 bits = 167
-address = "1AvLwGpkwTZH4qiwy1L4v6TuWXLMNrATN5"
+address = { value = "1AvLwGpkwTZH4qiwy1L4v6TuWXLMNrATN5", kind = "p2pkh", hash160 = "6ccfd1cdb43788738536e11e247b0ce31c093f0f" }
 prize = 0.167
 status = "swept"
 has_pubkey = true
 public_key = "03779c01b4badc5c3883f6ea2b93214a24796154c8eb967695dfc802bf074b4941"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "6ccfd1cdb43788738536e11e247b0ce31c093f0f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.167 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.167 }]
 
 [[puzzles]]
 bits = 168
-address = "1PojqbbzJHnn1X2mv6DCECNLUaD2nMssDp"
+address = { value = "1PojqbbzJHnn1X2mv6DCECNLUaD2nMssDp", kind = "p2pkh", hash160 = "fa29a9264b9c18fa5925e38d201934ed89e64dd6" }
 prize = 0.168
 status = "swept"
 has_pubkey = true
 public_key = "02788f82521d7557d30c9c4f8bc7098cda23c59729e9cf96057ea1dc49799bd399"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "fa29a9264b9c18fa5925e38d201934ed89e64dd6"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.168 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.168 }]
 
 [[puzzles]]
 bits = 169
-address = "1G3uazv67BcKRmPFvgvX4ijBTa2898cvCm"
+address = { value = "1G3uazv67BcKRmPFvgvX4ijBTa2898cvCm", kind = "p2pkh", hash160 = "a5169d8bc79e8cc94a36246de6bde7596cc9f4bb" }
 prize = 0.169
 status = "swept"
 has_pubkey = true
 public_key = "026efbd90dfd84d5bfb7a8ceb2755155d1d39a16be88db336ff18a8d844a269cba"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "a5169d8bc79e8cc94a36246de6bde7596cc9f4bb"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.169 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.169 }]
 
 [[puzzles]]
 bits = 170
-address = "1EW9W5sGdxVDxAtjRbCjgkZNtPH8ZzikeP"
+address = { value = "1EW9W5sGdxVDxAtjRbCjgkZNtPH8ZzikeP", kind = "p2pkh", hash160 = "941ccb7383109b47b841044c9f865785676b0918" }
 prize = 0.17
 status = "swept"
 has_pubkey = true
 public_key = "03e56c48f1bc4a6d06a2e0a4ad53c7674403dbfdaaeee3ecc86aff294b04997d61"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "941ccb7383109b47b841044c9f865785676b0918"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.17 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.17 }]
 
 [[puzzles]]
 bits = 171
-address = "17zzMMnj5h8StLhnrXpw8iBP21uujNC4Ap"
+address = { value = "17zzMMnj5h8StLhnrXpw8iBP21uujNC4Ap", kind = "p2pkh", hash160 = "4cc856b74f1be643a3a0ac65f5399e018aed7ae5" }
 prize = 0.171
 status = "swept"
 has_pubkey = true
 public_key = "021b6f7d2e3d33f99fa44985c68ae85827282c64701a2c663bd81e18a229a3562d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "4cc856b74f1be643a3a0ac65f5399e018aed7ae5"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.171 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.171 }]
 
 [[puzzles]]
 bits = 172
-address = "15LJKhwQJ7dYMBZX1mktskZqxX1aUCibkr"
+address = { value = "15LJKhwQJ7dYMBZX1mktskZqxX1aUCibkr", kind = "p2pkh", hash160 = "2f86ddd3fac7bf830020f97c46b33aabc891e132" }
 prize = 0.172
 status = "swept"
 has_pubkey = true
 public_key = "02ed75f534f534c536d0732acd70af3e0d173c1f6885381edf8469d1e5a4cae716"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "2f86ddd3fac7bf830020f97c46b33aabc891e132"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.172 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.172 }]
 
 [[puzzles]]
 bits = 173
-address = "1Mkodin3C3drVaV9JNk1o3i4n4gVGe9GVx"
+address = { value = "1Mkodin3C3drVaV9JNk1o3i4n4gVGe9GVx", kind = "p2pkh", hash160 = "e3ab5452f79c3ba677d230621f865667114ace03" }
 prize = 0.173
 status = "swept"
 has_pubkey = true
 public_key = "0233d5bd5790203edab5c63839bee1765735c35254ec24f3073f65d99e1dabf90e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "e3ab5452f79c3ba677d230621f865667114ace03"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.173 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.173 }]
 
 [[puzzles]]
 bits = 174
-address = "1C6dHU1gQtVUXZmeXQuQc3EgDJbiLbxFZJ"
+address = { value = "1C6dHU1gQtVUXZmeXQuQc3EgDJbiLbxFZJ", kind = "p2pkh", hash160 = "79b9c06f479cde2a04c871b7534f1d4706c6411a" }
 prize = 0.174
 status = "swept"
 has_pubkey = true
 public_key = "03c11209f91946eb81b603d046a296f5754967897d471980fe43ea1aec8bf2ad7c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "79b9c06f479cde2a04c871b7534f1d4706c6411a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.174 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.174 }]
 
 [[puzzles]]
 bits = 175
-address = "1DxZJy7AkqLVAQ5rtSUKfrR3yPE5u5ygk6"
+address = { value = "1DxZJy7AkqLVAQ5rtSUKfrR3yPE5u5ygk6", kind = "p2pkh", hash160 = "8e235bafd009b1bf67a8475cf1687b09b23c525f" }
 prize = 0.175
 status = "swept"
 has_pubkey = true
 public_key = "02cb5f1f0d3dd67f0f162353490d98219982f5095bd32daa6c020806cf59ea2c2e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "8e235bafd009b1bf67a8475cf1687b09b23c525f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.175 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.175 }]
 
 [[puzzles]]
 bits = 176
-address = "1NcytLwdqJa8DsQPa9NwkxJTQcx1rZy85A"
+address = { value = "1NcytLwdqJa8DsQPa9NwkxJTQcx1rZy85A", kind = "p2pkh", hash160 = "ed28af7ebd057c69f2f9f5852fcff8da51b32571" }
 prize = 0.176
 status = "swept"
 has_pubkey = true
 public_key = "02ba9f479c758f5b2842ddef8414e70acfc943d2584258709352061a100e410ee4"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "ed28af7ebd057c69f2f9f5852fcff8da51b32571"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.176 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.176 }]
 
 [[puzzles]]
 bits = 177
-address = "163vG9mKmAsrvmq42MBDPjf9axZyEgBc9R"
+address = { value = "163vG9mKmAsrvmq42MBDPjf9axZyEgBc9R", kind = "p2pkh", hash160 = "3765ebcb90c64c4167674c8c2f35ad3d12245fb5" }
 prize = 0.177
 status = "swept"
 has_pubkey = true
 public_key = "028ae59ec009a07fad636a066f72d567a1fe9a37492b40688c2edfe18de00f284c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3765ebcb90c64c4167674c8c2f35ad3d12245fb5"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.177 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.177 }]
 
 [[puzzles]]
 bits = 178
-address = "12ATwA5VvoPDinSymcQpCAXPLApAVLN24z"
+address = { value = "12ATwA5VvoPDinSymcQpCAXPLApAVLN24z", kind = "p2pkh", hash160 = "0cc25a433319a84636805fd00f8862aeb3fc8cdd" }
 prize = 0.178
 status = "swept"
 has_pubkey = true
 public_key = "035fd8708ca357691c50a49b0d339227360049b3156c3d32d1c54a315393bda35e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "0cc25a433319a84636805fd00f8862aeb3fc8cdd"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.178 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.178 }]
 
 [[puzzles]]
 bits = 179
-address = "12fXbBE7kTfqYk8dYyU9bw7XfKVwEqXnzg"
+address = { value = "12fXbBE7kTfqYk8dYyU9bw7XfKVwEqXnzg", kind = "p2pkh", hash160 = "12417789f9448e8d151699534c43c5b419e4ab7a" }
 prize = 0.179
 status = "swept"
 has_pubkey = true
 public_key = "02064bbc39fd98afca5085c5e9a006c8bb0e466adef24a911e635f835c8061c15f"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "12417789f9448e8d151699534c43c5b419e4ab7a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.179 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.179 }]
 
 [[puzzles]]
 bits = 180
-address = "1EkYsB1C7deWxiVUULeZpr42AdYWhv4PEX"
+address = { value = "1EkYsB1C7deWxiVUULeZpr42AdYWhv4PEX", kind = "p2pkh", hash160 = "96d61f034c1d3db504e6c84e1d9b5e47b3bbb6ef" }
 prize = 0.18
 status = "swept"
 has_pubkey = true
 public_key = "0329420514190479e81640f967e686e2d950e231edd021fc63a17193dac2969a3d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "96d61f034c1d3db504e6c84e1d9b5e47b3bbb6ef"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.18 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.18 }]
 
 [[puzzles]]
 bits = 181
-address = "1MPQyhXBT2FpUMCiv5YX3yacKvmc9P5x6S"
+address = { value = "1MPQyhXBT2FpUMCiv5YX3yacKvmc9P5x6S", kind = "p2pkh", hash160 = "df9faeaaf5c84fb9aca49f923d7ae0286754f13f" }
 prize = 0.181
 status = "swept"
 has_pubkey = true
 public_key = "02cd62a1cefed68821c2fc3a0e763a0178a323cfba08cde5c0321caa644f1052de"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "df9faeaaf5c84fb9aca49f923d7ae0286754f13f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.181 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.181 }]
 
 [[puzzles]]
 bits = 182
-address = "1GZyxmpgtRJNaW1zEhPAa81xZDEJSdwbbZ"
+address = { value = "1GZyxmpgtRJNaW1zEhPAa81xZDEJSdwbbZ", kind = "p2pkh", hash160 = "aac6bf269ddce4d550f9c58eedc720b85ba1dc49" }
 prize = 0.182
 status = "swept"
 has_pubkey = true
 public_key = "03f7aafd4bcc8478efb01ff830655d88cb60399e3179e24eb0146b013ee5c4d6a1"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "aac6bf269ddce4d550f9c58eedc720b85ba1dc49"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.182 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.182 }]
 
 [[puzzles]]
 bits = 183
-address = "12E2HWQVHzuGKAQVvPUkHWwibAJfnmcHW1"
+address = { value = "12E2HWQVHzuGKAQVvPUkHWwibAJfnmcHW1", kind = "p2pkh", hash160 = "0d6e9b09e523e71ad7b9873dadee0d0bc788033c" }
 prize = 0.183
 status = "swept"
 has_pubkey = true
 public_key = "036d249dae9d1f3afe5c85ec6f34561a2373d6c0b6cfa8ca1b4ae00d1937e7a59b"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "0d6e9b09e523e71ad7b9873dadee0d0bc788033c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.183 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.183 }]
 
 [[puzzles]]
 bits = 184
-address = "14J1fXY2E3fbxjp1zpfqRhk5BNQ4pb97Rs"
+address = { value = "14J1fXY2E3fbxjp1zpfqRhk5BNQ4pb97Rs", kind = "p2pkh", hash160 = "242000d101c4c5b143c63f12ae08caa81d837c28" }
 prize = 0.184
 status = "swept"
 has_pubkey = true
 public_key = "0377059f597c2e14d648807db27c8540f7cdd7e176c5baf979dcc00f251bdec6aa"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "242000d101c4c5b143c63f12ae08caa81d837c28"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.184 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.184 }]
 
 [[puzzles]]
 bits = 185
-address = "1HqHHuFzZhtTtyGbAWCS49qGnCBSEhBSFT"
+address = { value = "1HqHHuFzZhtTtyGbAWCS49qGnCBSEhBSFT", kind = "p2pkh", hash160 = "b8a393fd03783ac177243e8c4313a4221b049b8a" }
 prize = 0.185
 status = "swept"
 has_pubkey = true
 public_key = "0208ce81549c729647d7747a6a7e304104435fae445afb4fa90fd384f2640f0ed9"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "b8a393fd03783ac177243e8c4313a4221b049b8a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.185 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.185 }]
 
 [[puzzles]]
 bits = 186
-address = "1BJXBDt4e1uaorXPototucUGNRme57nAqt"
+address = { value = "1BJXBDt4e1uaorXPototucUGNRme57nAqt", kind = "p2pkh", hash160 = "710184e0443717cc62b086824b793f4e011b4456" }
 prize = 0.186
 status = "swept"
 has_pubkey = true
 public_key = "03ab1c8c3d6b773758c2a765dd33fa0b9804c55754f9a9278a158a2d02a6edd1a6"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "710184e0443717cc62b086824b793f4e011b4456"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.186 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.186 }]
 
 [[puzzles]]
 bits = 187
-address = "19ct7Egfi5j6jSefj8X4d5eXJQUmyhtXjC"
+address = { value = "19ct7Egfi5j6jSefj8X4d5eXJQUmyhtXjC", kind = "p2pkh", hash160 = "5e8a3a32df85af78e2ce3493985ff4ae2da00623" }
 prize = 0.187
 status = "swept"
 has_pubkey = true
 public_key = "028393d6e394d960b1b7e239707d87595f85b7bdca480dafd39d4797124740d9ef"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "5e8a3a32df85af78e2ce3493985ff4ae2da00623"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.187 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.187 }]
 
 [[puzzles]]
 bits = 188
-address = "1DyWSY1dA3wyjo4eMuQCPfrm3dV96xDDSU"
+address = { value = "1DyWSY1dA3wyjo4eMuQCPfrm3dV96xDDSU", kind = "p2pkh", hash160 = "8e5160f5d3f432f7421f189d1888b85ed8337180" }
 prize = 0.188
 status = "swept"
 has_pubkey = true
 public_key = "039705ff013b8514ee6eded8af52879598d19306f3e252f153dbfa02baa06d7dde"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "8e5160f5d3f432f7421f189d1888b85ed8337180"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.188 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.188 }]
 
 [[puzzles]]
 bits = 189
-address = "1PiLrDyeXtncnsvcVAGGcNnpzQVRCG3fwS"
+address = { value = "1PiLrDyeXtncnsvcVAGGcNnpzQVRCG3fwS", kind = "p2pkh", hash160 = "f92463f967ffc9cea3e1ef846ff106b591e38e68" }
 prize = 0.189
 status = "swept"
 has_pubkey = true
 public_key = "027a9e387d83df7847566373ef601f2b6dd9adbaf3fde5582199ed71f4b8ca9e08"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "f92463f967ffc9cea3e1ef846ff106b591e38e68"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.189 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.189 }]
 
 [[puzzles]]
 bits = 190
-address = "1HUoYzoEn2a4WxKvnYYbnR9GKrVqAfq7oY"
+address = { value = "1HUoYzoEn2a4WxKvnYYbnR9GKrVqAfq7oY", kind = "p2pkh", hash160 = "b4c41a566543c9133f45361d6df0895319113538" }
 prize = 0.19
 status = "swept"
 has_pubkey = true
 public_key = "03eb37cc02df3bd83f67e581116b2e08b1b4f27354a21d6345fe17484f4ba2ab8a"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "b4c41a566543c9133f45361d6df0895319113538"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.19 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.19 }]
 
 [[puzzles]]
 bits = 191
-address = "19vnME8b28SzJDuEFNShAG5JCR63V1zzV"
+address = { value = "19vnME8b28SzJDuEFNShAG5JCR63V1zzV", kind = "p2pkh", hash160 = "01b038f889ed602266f2c6647f657713e52d8cac" }
 prize = 0.191
 status = "swept"
 has_pubkey = true
 public_key = "03bd9d14ad1d7d2c3d1f46b5f2c82142a5c0784ff4506c04ae0a99d9737e1630d1"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "01b038f889ed602266f2c6647f657713e52d8cac"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.191 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.191 }]
 
 [[puzzles]]
 bits = 192
-address = "1GWTEv76C8cusq4h5gV3rLjeFhBkGBHSKg"
+address = { value = "1GWTEv76C8cusq4h5gV3rLjeFhBkGBHSKg", kind = "p2pkh", hash160 = "aa1bda87c542102bc484b1fc54f93764f0ccd701" }
 prize = 0.192
 status = "swept"
 has_pubkey = true
 public_key = "024e1799de117b044ea4778a77f0a6267bb84b182f55093be7ed0e8f703b74e5bd"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "aa1bda87c542102bc484b1fc54f93764f0ccd701"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.192 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.192 }]
 
 [[puzzles]]
 bits = 193
-address = "1NHh2fQDm7KyBs8HRFkVtHgMzkmufk6mNW"
+address = { value = "1NHh2fQDm7KyBs8HRFkVtHgMzkmufk6mNW", kind = "p2pkh", hash160 = "e982b609d7049607fb087a936464fe8915087aee" }
 prize = 0.193
 status = "swept"
 has_pubkey = true
 public_key = "02a7cbaf2cc78bf6686b7a2a2cbcd2d0ed6e03e56f481e18212508364b682ca711"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "e982b609d7049607fb087a936464fe8915087aee"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.193 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.193 }]
 
 [[puzzles]]
 bits = 194
-address = "1oW8VFRNVKhbzzq8NWNutDYDzv1CzAHAj"
+address = { value = "1oW8VFRNVKhbzzq8NWNutDYDzv1CzAHAj", kind = "p2pkh", hash160 = "08cb7331dccb902b5db0a30dcc1ba8adbd6fe4d0" }
 prize = 0.194
 status = "swept"
 has_pubkey = true
 public_key = "024e951c7b8d0630a84f5f79b6a8ddae01ff2166f322fc4558d20c97aacd8f2839"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "08cb7331dccb902b5db0a30dcc1ba8adbd6fe4d0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.194 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.194 }]
 
 [[puzzles]]
 bits = 195
-address = "16q15tpaHQFUENUmRPLgiidCMWLcDpVEgs"
+address = { value = "16q15tpaHQFUENUmRPLgiidCMWLcDpVEgs", kind = "p2pkh", hash160 = "3fecaa5f1295e3374ef2b04a365523cfcb56305a" }
 prize = 0.195
 status = "swept"
 has_pubkey = true
 public_key = "029cfb4b5b2830188161b359fc1fb7ef3023b3212889ee8565a7989de774af192d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3fecaa5f1295e3374ef2b04a365523cfcb56305a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.195 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.195 }]
 
 [[puzzles]]
 bits = 196
-address = "1AH4d8Bss6eFyugZaN2qPXMBH69T946dSK"
+address = { value = "1AH4d8Bss6eFyugZaN2qPXMBH69T946dSK", kind = "p2pkh", hash160 = "65c2cfc6b38650c00242435f1b041a5fb1b733ee" }
 prize = 0.196
 status = "swept"
 has_pubkey = true
 public_key = "02e56e407ea984475f21ee82e96822c541967dae2a68e85ef883ec46c7646d6f67"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "65c2cfc6b38650c00242435f1b041a5fb1b733ee"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.196 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.196 }]
 
 [[puzzles]]
 bits = 197
-address = "12gDPuHvZBh6FSjyhHhyDDkM38Y2wyDGQt"
+address = { value = "12gDPuHvZBh6FSjyhHhyDDkM38Y2wyDGQt", kind = "p2pkh", hash160 = "1262b1eb58a0e55dc874e8c2d097e61194358388" }
 prize = 0.197
 status = "swept"
 has_pubkey = true
 public_key = "028ab0a2c3a3413f9ea995a2bd5c7a72b79b2c6f76bf7cf49d840028a618046fd3"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "1262b1eb58a0e55dc874e8c2d097e61194358388"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.197 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.197 }]
 
 [[puzzles]]
 bits = 198
-address = "12jFRwZFUrxUTtuyVzw9FNJsJa7mjBgfca"
+address = { value = "12jFRwZFUrxUTtuyVzw9FNJsJa7mjBgfca", kind = "p2pkh", hash160 = "12f5a4496acc2393b6b56408ae7b3e07b6dc9b93" }
 prize = 0.198
 status = "swept"
 has_pubkey = true
 public_key = "0245f61026852cde2db15de4b129ad0e3c54aba03ed9b0f676eb9dfb680277d569"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "12f5a4496acc2393b6b56408ae7b3e07b6dc9b93"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.198 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.198 }]
 
 [[puzzles]]
 bits = 199
-address = "1BNkFNU3eJz8jDfTkTwe7XmF18BfQwfqW7"
+address = { value = "1BNkFNU3eJz8jDfTkTwe7XmF18BfQwfqW7", kind = "p2pkh", hash160 = "71ce182dba6c2838d69248017141117721a7200a" }
 prize = 0.199
 status = "swept"
 has_pubkey = true
 public_key = "03ec5cd862b5699f09e5341b4315b2a548024718fe9ce70d205dbfbbface07d7ee"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "71ce182dba6c2838d69248017141117721a7200a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.199 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.199 }]
 
 [[puzzles]]
 bits = 200
-address = "1DEDEKJVEmXvEqwg3wbq8c1ZNobo4tNw4h"
+address = { value = "1DEDEKJVEmXvEqwg3wbq8c1ZNobo4tNw4h", kind = "p2pkh", hash160 = "8621202a5e010769fb0fd1a08027f41e173c3bb5" }
 prize = 0.2
 status = "swept"
 has_pubkey = true
 public_key = "03fe993e313ad3c5e8ae4d7e99a8cd5131ae04896270e48082d5965dba9616032d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "8621202a5e010769fb0fd1a08027f41e173c3bb5"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.2 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.2 }]
 
 [[puzzles]]
 bits = 201
-address = "1DA2RexqNkbVhzfkmQDHRMfKrdesgyMMdQ"
+address = { value = "1DA2RexqNkbVhzfkmQDHRMfKrdesgyMMdQ", kind = "p2pkh", hash160 = "85567151f330b69bac3eba86bb3aedd8813ec2b7" }
 prize = 0.201
 status = "swept"
 has_pubkey = true
 public_key = "03346fd1b1ca7a7eb88e4b7af48d678a42e8ca8d607d8e4e2967d16394c360d014"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "85567151f330b69bac3eba86bb3aedd8813ec2b7"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.201 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.201 }]
 
 [[puzzles]]
 bits = 202
-address = "19Ho5YB6y8qRCdUMxWpXqrm8N4AKAq7ZWS"
+address = { value = "19Ho5YB6y8qRCdUMxWpXqrm8N4AKAq7ZWS", kind = "p2pkh", hash160 = "5aee20366a5523246e1c43dc48462878b0d4806e" }
 prize = 0.202
 status = "swept"
 has_pubkey = true
 public_key = "02669d985185d1894541f6ab7ea7fd57dace5bf97f2c73736b205ab07a5685354b"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "5aee20366a5523246e1c43dc48462878b0d4806e"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.202 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.202 }]
 
 [[puzzles]]
 bits = 203
-address = "1DVWn7PuRBmsdTBKiboBdSREHdAtSoN6BB"
+address = { value = "1DVWn7PuRBmsdTBKiboBdSREHdAtSoN6BB", kind = "p2pkh", hash160 = "89060378aec62c83cd6e20d92865cf9ca80549b1" }
 prize = 0.203
 status = "swept"
 has_pubkey = true
 public_key = "034fd997afbe4608f743661ae417c5706b044d9d5532a51aef5f4cb244f5f5dce1"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "89060378aec62c83cd6e20d92865cf9ca80549b1"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.203 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.203 }]
 
 [[puzzles]]
 bits = 204
-address = "14CMU6qvv55Y7xJdVw64ey5yfUP4BZAjct"
+address = { value = "14CMU6qvv55Y7xJdVw64ey5yfUP4BZAjct", kind = "p2pkh", hash160 = "230e09c32f5aa23763f8e7c770cee5b5cf4359c1" }
 prize = 0.204
 status = "swept"
 has_pubkey = true
 public_key = "038e2790adcbe6d0c89c0c23763c52608ad0fe2a757e9910550f45bfb1855ad54c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "230e09c32f5aa23763f8e7c770cee5b5cf4359c1"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.204 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.204 }]
 
 [[puzzles]]
 bits = 205
-address = "1DHL5NuXPjwDsNnXyzAgZTAMM4aYUc1zFW"
+address = { value = "1DHL5NuXPjwDsNnXyzAgZTAMM4aYUc1zFW", kind = "p2pkh", hash160 = "86b816944ed6fce46ca955b80897996b016f8be0" }
 prize = 0.205
 status = "swept"
 has_pubkey = true
 public_key = "030fad8d46d7a7f4e5b5c76a09a05166c8f7515651f0c73bf8329353f412699c99"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "86b816944ed6fce46ca955b80897996b016f8be0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.205 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.205 }]
 
 [[puzzles]]
 bits = 206
-address = "1UwsEPMF1NZTWJAuymsLVJpqetBZ3Q9sJ"
+address = { value = "1UwsEPMF1NZTWJAuymsLVJpqetBZ3Q9sJ", kind = "p2pkh", hash160 = "054907e50b2feceb0b75f850fd764c197844fea0" }
 prize = 0.206
 status = "swept"
 has_pubkey = true
 public_key = "0291a1ff9572bcbafd8dabe85c90e10a458a4f71e759747918d4aa1f56af8a66af"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "054907e50b2feceb0b75f850fd764c197844fea0"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.206 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.206 }]
 
 [[puzzles]]
 bits = 207
-address = "16aELF1f75o464ZhtAZUwbc4ctFQZxS8qi"
+address = { value = "16aELF1f75o464ZhtAZUwbc4ctFQZxS8qi", kind = "p2pkh", hash160 = "3d217c047cabb55395cd9618cee124683ea5c998" }
 prize = 0.207
 status = "swept"
 has_pubkey = true
 public_key = "030fb4b479aaa51c07c2f660501ccf73a6aaef84e2065ad1dcf97125a5d7248258"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3d217c047cabb55395cd9618cee124683ea5c998"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.207 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.207 }]
 
 [[puzzles]]
 bits = 208
-address = "15TJ3wPvdviupvKQFm8hLeXSzeMSq7LSJ2"
+address = { value = "15TJ3wPvdviupvKQFm8hLeXSzeMSq7LSJ2", kind = "p2pkh", hash160 = "30d98d22a09bf062c9b3706af3c059a72bcb7879" }
 prize = 0.208
 status = "swept"
 has_pubkey = true
 public_key = "03762e52fe281f880581dcd00bf80a7fd949af3439b479aba16b6fa5b04733f4b4"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "30d98d22a09bf062c9b3706af3c059a72bcb7879"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.208 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.208 }]
 
 [[puzzles]]
 bits = 209
-address = "1JgrGoQbvJS7UnX6j4myiCxo6Q3gyo5Ujk"
+address = { value = "1JgrGoQbvJS7UnX6j4myiCxo6Q3gyo5Ujk", kind = "p2pkh", hash160 = "c2037dcac7d46e66c4e06c289c3ccd3170438332" }
 prize = 0.209
 status = "swept"
 has_pubkey = true
 public_key = "0243874c891b55668295d5fb6a734fa8b9c4f73eb80cd4f3be3ed7de520e974e9f"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "c2037dcac7d46e66c4e06c289c3ccd3170438332"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.209 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.209 }]
 
 [[puzzles]]
 bits = 210
-address = "14Xm5DjBUQTJCzeGhyrhVsxkK8p35srk1S"
+address = { value = "14Xm5DjBUQTJCzeGhyrhVsxkK8p35srk1S", kind = "p2pkh", hash160 = "26b9a572ce3f674c9c8d3a0f15386d6848783c25" }
 prize = 0.21
 status = "swept"
 has_pubkey = true
 public_key = "03628e54188ca8c8c0b73fdb12064f195417f9fd98a7b0763d83eda2518c526f44"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "26b9a572ce3f674c9c8d3a0f15386d6848783c25"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.21 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.21 }]
 
 [[puzzles]]
 bits = 211
-address = "19yhSoza8oK3ioCSydMuAGJs4Mm3FwCTht"
+address = { value = "19yhSoza8oK3ioCSydMuAGJs4Mm3FwCTht", kind = "p2pkh", hash160 = "627a0fd9f1c2034f9d643a355621842288cf4551" }
 prize = 0.211
 status = "swept"
 has_pubkey = true
 public_key = "036f164c6a628d94338a9dc9dfc1cc2f91a3a9382c198bb05f51fbbc34c6cc583e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "627a0fd9f1c2034f9d643a355621842288cf4551"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.211 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.211 }]
 
 [[puzzles]]
 bits = 212
-address = "1JXw9i8dEZGH29mUiuKjWXK9L27r2TerLQ"
+address = { value = "1JXw9i8dEZGH29mUiuKjWXK9L27r2TerLQ", kind = "p2pkh", hash160 = "c053d1c7b2e7e27c624dcb8087549876af73aa03" }
 prize = 0.212
 status = "swept"
 has_pubkey = true
 public_key = "020df4abc8bae9c000ea2357b014befe3e6d13dd63951ac0b2b66b37eab76b7ead"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "c053d1c7b2e7e27c624dcb8087549876af73aa03"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.212 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.212 }]
 
 [[puzzles]]
 bits = 213
-address = "1CNNth43uiVypxHmZLC8hWZsb7UiP7wSkY"
+address = { value = "1CNNth43uiVypxHmZLC8hWZsb7UiP7wSkY", kind = "p2pkh", hash160 = "7cb4648719aedaf874354cadf986e89458eb58cc" }
 prize = 0.213
 status = "swept"
 has_pubkey = true
 public_key = "024b5c68b748907bc07afa2f4d9cfeef5524d0675ee4b5a39f2e9e7b7b85f2bd9f"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "7cb4648719aedaf874354cadf986e89458eb58cc"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.213 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.213 }]
 
 [[puzzles]]
 bits = 214
-address = "16ocVeZDpqcvyMvzAH1r2LR75uEzRhkyV2"
+address = { value = "16ocVeZDpqcvyMvzAH1r2LR75uEzRhkyV2", kind = "p2pkh", hash160 = "3fa96459d3e03e94794724b8605c9ae47a106862" }
 prize = 0.214
 status = "swept"
 has_pubkey = true
 public_key = "033fb8f6eb9cd60aca4f5ec48c7bd81fbe2c221c7701bcb93be5f50a810055c965"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3fa96459d3e03e94794724b8605c9ae47a106862"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.214 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.214 }]
 
 [[puzzles]]
 bits = 215
-address = "15x3tRVyn9SRaxfbFUzqETmCJiz46Vs247"
+address = { value = "15x3tRVyn9SRaxfbFUzqETmCJiz46Vs247", kind = "p2pkh", hash160 = "3649ca67657d482484f49f8f5c8cdb5222c8700f" }
 prize = 0.215
 status = "swept"
 has_pubkey = true
 public_key = "02dcab1861d56d3b6ca4d741f885c9f7b34d91b460f90b3dc1983acf701ca8092f"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3649ca67657d482484f49f8f5c8cdb5222c8700f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.215 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.215 }]
 
 [[puzzles]]
 bits = 216
-address = "197K7MdYhnN88gcJouJRxMiSAHHfWuPrXC"
+address = { value = "197K7MdYhnN88gcJouJRxMiSAHHfWuPrXC", kind = "p2pkh", hash160 = "58f29e811ffece9aaf65c7a360382ebcea3a2f18" }
 prize = 0.216
 status = "swept"
 has_pubkey = true
 public_key = "022f02cc3458301883c9bd15fe341384f94ce48076f836815f7b89901f3a27abc4"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "58f29e811ffece9aaf65c7a360382ebcea3a2f18"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.216 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.216 }]
 
 [[puzzles]]
 bits = 217
-address = "1MDsNYfC4LErgwUDqfQ5BgFJqv5bs4Frkn"
+address = { value = "1MDsNYfC4LErgwUDqfQ5BgFJqv5bs4Frkn", kind = "p2pkh", hash160 = "ddd18e224de138253a990a4cc8d8e7aaa3998914" }
 prize = 0.217
 status = "swept"
 has_pubkey = true
 public_key = "023dccddd7460b8000e6ac7bb14f98cad9aeb4b4f858c2a655738ce141d71224fb"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "ddd18e224de138253a990a4cc8d8e7aaa3998914"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.217 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.217 }]
 
 [[puzzles]]
 bits = 218
-address = "1BDTXmiyyzq9i79RGGTW7cjmYJbxKoV27e"
+address = { value = "1BDTXmiyyzq9i79RGGTW7cjmYJbxKoV27e", kind = "p2pkh", hash160 = "700c655d586d1a06b0185b12007a1b195d60271c" }
 prize = 0.218
 status = "swept"
 has_pubkey = true
 public_key = "03d8c17e24c72388998ebe82837a555e57d1db6162738cec8963384c367e393906"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "700c655d586d1a06b0185b12007a1b195d60271c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.218 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.218 }]
 
 [[puzzles]]
 bits = 219
-address = "1EiJ59LPWDezXwfAGFTcoEKdNhvRTriBXy"
+address = { value = "1EiJ59LPWDezXwfAGFTcoEKdNhvRTriBXy", kind = "p2pkh", hash160 = "9668f0ad5f1eaa5c8e68baf1eaa07c1ea16a88de" }
 prize = 0.219
 status = "swept"
 has_pubkey = true
 public_key = "02ef830a543b3b50c3fc7e42bbc0938039f8d3e19a1e862012f281c51f3581d77d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "9668f0ad5f1eaa5c8e68baf1eaa07c1ea16a88de"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.219 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.219 }]
 
 [[puzzles]]
 bits = 220
-address = "1rirV4Y2NxGwKNQNojJhz61jEctni8fvb"
+address = { value = "1rirV4Y2NxGwKNQNojJhz61jEctni8fvb", kind = "p2pkh", hash160 = "096751c3cb56d4d163186085c81fc8dcf5bfa4ec" }
 prize = 0.22
 status = "swept"
 has_pubkey = true
 public_key = "022cc796d5a8ec2c871640152a0db6ffd2b4ea957c8f5ecf706fbc383fa5ad7696"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "096751c3cb56d4d163186085c81fc8dcf5bfa4ec"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.22 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.22 }]
 
 [[puzzles]]
 bits = 221
-address = "1NxgWntAdMugSNFHEXYizYwk3UjxKPxcDF"
+address = { value = "1NxgWntAdMugSNFHEXYizYwk3UjxKPxcDF", kind = "p2pkh", hash160 = "f0e280f15876be99ab63c8aaa4f934f777ed369b" }
 prize = 0.221
 status = "swept"
 has_pubkey = true
 public_key = "028a874fe6f1ab00358d0b610d536fd67f049c98069eeb35585549250ef9fff4c5"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "f0e280f15876be99ab63c8aaa4f934f777ed369b"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.221 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.221 }]
 
 [[puzzles]]
 bits = 222
-address = "17A75vEkPPVeY9MMMXUY9M2JUHbbNyVAWC"
+address = { value = "17A75vEkPPVeY9MMMXUY9M2JUHbbNyVAWC", kind = "p2pkh", hash160 = "438993e343b3317a4833a709894145f2374a95f9" }
 prize = 0.222
 status = "swept"
 has_pubkey = true
 public_key = "021536a0aa8cdb5061debba4f236d311a570f6de6d483419fa23c147f543765602"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "438993e343b3317a4833a709894145f2374a95f9"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.222 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.222 }]
 
 [[puzzles]]
 bits = 223
-address = "1NUVBXgX35Uax4fpziV7VGMJyji3mUzZbt"
+address = { value = "1NUVBXgX35Uax4fpziV7VGMJyji3mUzZbt", kind = "p2pkh", hash160 = "eb8d65ae18eba8f6a1fcffe0b37e87fa34b09a70" }
 prize = 0.223
 status = "swept"
 has_pubkey = true
 public_key = "034cfb3bcb83ed739ecc9abc84f68ffaa430f2d685bebfaf8cefaaabcd2b53d984"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "eb8d65ae18eba8f6a1fcffe0b37e87fa34b09a70"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.223 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.223 }]
 
 [[puzzles]]
 bits = 224
-address = "1F6yxcbDzjumeN77DiABMXzPcvtAdnaoPF"
+address = { value = "1F6yxcbDzjumeN77DiABMXzPcvtAdnaoPF", kind = "p2pkh", hash160 = "9ab3633c60100b0dd631bf1c6755abaea7bc0445" }
 prize = 0.224
 status = "swept"
 has_pubkey = true
 public_key = "02a1cf7a8cb1bdd05701aa57ef6e5a9ce28950d93e2369d5fa11ec5bdc8d4ce9d1"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "9ab3633c60100b0dd631bf1c6755abaea7bc0445"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.224 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.224 }]
 
 [[puzzles]]
 bits = 225
-address = "16YvGEYhAwjf2duwvH8jbFMfVCnY6XiQTq"
+address = { value = "16YvGEYhAwjf2duwvH8jbFMfVCnY6XiQTq", kind = "p2pkh", hash160 = "3ce1fc3304d09e7984c5766fd1134c1e8979821a" }
 prize = 0.225
 status = "swept"
 has_pubkey = true
 public_key = "03e1819c7597f314943bf847e6ec36c4c95ac1b3ead9948b90e9a2729357712ff7"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "3ce1fc3304d09e7984c5766fd1134c1e8979821a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.225 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.225 }]
 
 [[puzzles]]
 bits = 226
-address = "1HtbZg9mPjYcMDMDNyXaFjHX5e7ZPUwWAp"
+address = { value = "1HtbZg9mPjYcMDMDNyXaFjHX5e7ZPUwWAp", kind = "p2pkh", hash160 = "b944142155bef6fa7280d5f7f8eae49511349ebf" }
 prize = 0.226
 status = "swept"
 has_pubkey = true
 public_key = "020d896eac113fac98c2a4a44b1488087b3b4c2d8f2563d2a41789f0324ad62cc7"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "b944142155bef6fa7280d5f7f8eae49511349ebf"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.226 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.226 }]
 
 [[puzzles]]
 bits = 227
-address = "15a9nXpjnQzw2o5kmvGyKzv7anZkYFHwdK"
+address = { value = "15a9nXpjnQzw2o5kmvGyKzv7anZkYFHwdK", kind = "p2pkh", hash160 = "32259030b93d8f20268aaa2c5222f9366faa2fc3" }
 prize = 0.227
 status = "swept"
 has_pubkey = true
 public_key = "02f73589feb03e8ed1de43cc7748111e2f1d73a2a06679951addeee165d378f23e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "32259030b93d8f20268aaa2c5222f9366faa2fc3"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.227 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.227 }]
 
 [[puzzles]]
 bits = 228
-address = "18zsQK8ezT32qCqgLJQMkhqyKNwpCP3JU3"
+address = { value = "18zsQK8ezT32qCqgLJQMkhqyKNwpCP3JU3", kind = "p2pkh", hash160 = "57baa9ea3f683b444a06702492443a9057ce2c96" }
 prize = 0.228
 status = "swept"
 has_pubkey = true
 public_key = "037ac4f241f6ba433da340b08a081323a93c0966fca5c0757685005f8396b09628"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "57baa9ea3f683b444a06702492443a9057ce2c96"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.228 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.228 }]
 
 [[puzzles]]
 bits = 229
-address = "1AaBhpTnfCin9nCrai2msXzCHoVmwkAe2N"
+address = { value = "1AaBhpTnfCin9nCrai2msXzCHoVmwkAe2N", kind = "p2pkh", hash160 = "68ffcb39707615a254428f084c859376fa7144be" }
 prize = 0.229
 status = "swept"
 has_pubkey = true
 public_key = "020d64789d26c0363a2f284a1cddad7b6ab7dd41d65d5afe6ce7554214d4666518"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "68ffcb39707615a254428f084c859376fa7144be"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.229 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.229 }]
 
 [[puzzles]]
 bits = 230
-address = "13Jtm1mm33Uke7PbmTBYGNZGU7rXUsVs3e"
+address = { value = "13Jtm1mm33Uke7PbmTBYGNZGU7rXUsVs3e", kind = "p2pkh", hash160 = "1952876e85b0e6fe7c2557c8345975fd44700f06" }
 prize = 0.23
 status = "swept"
 has_pubkey = true
 public_key = "0216dc9de7fd808beff7fb3bc63767ef34beb0a51b4daf40151bc346781185ceec"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "1952876e85b0e6fe7c2557c8345975fd44700f06"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.23 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.23 }]
 
 [[puzzles]]
 bits = 231
-address = "18aBXRctVrWN9naDGhKrLdZViNfLJfCdbF"
+address = { value = "18aBXRctVrWN9naDGhKrLdZViNfLJfCdbF", kind = "p2pkh", hash160 = "530f6487090bda616a7846f68160ddd886fbdf24" }
 prize = 0.231
 status = "swept"
 has_pubkey = true
 public_key = "0378a0cae3e8275916f41b25838e45a8f4c8829c3b1b937c1b1749fd77b23177c1"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "530f6487090bda616a7846f68160ddd886fbdf24"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.231 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.231 }]
 
 [[puzzles]]
 bits = 232
-address = "1MEEjd99pkEyCdiqVSCa8Jqjaun7fsEXaG"
+address = { value = "1MEEjd99pkEyCdiqVSCa8Jqjaun7fsEXaG", kind = "p2pkh", hash160 = "dde3637371e3638ef51b3753c028d84902153ea8" }
 prize = 0.232
 status = "swept"
 has_pubkey = true
 public_key = "03d9dd7c018dcf2a57a4d6c4299983c631ff8ab32eb72b57cfcf25be5366a9ed21"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "dde3637371e3638ef51b3753c028d84902153ea8"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.232 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.232 }]
 
 [[puzzles]]
 bits = 233
-address = "1NnefTEeKQQAts37cQHzVx8oPrUu8LWyUK"
+address = { value = "1NnefTEeKQQAts37cQHzVx8oPrUu8LWyUK", kind = "p2pkh", hash160 = "eefccc98b21f6748888b7b682d9f3ead55796890" }
 prize = 0.233
 status = "swept"
 has_pubkey = true
 public_key = "021b6cde6068c69f1156c044dabdf4cf4bef6cc4eb020ff0dc74e03633f72403a8"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "eefccc98b21f6748888b7b682d9f3ead55796890"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.233 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.233 }]
 
 [[puzzles]]
 bits = 234
-address = "1FYbLcutmRbvu4yUeLmC4TES2Q3ChhXYY"
+address = { value = "1FYbLcutmRbvu4yUeLmC4TES2Q3ChhXYY", kind = "p2pkh", hash160 = "02c031f6bc39053653a093d95511eb1197c5029c" }
 prize = 0.234
 status = "swept"
 has_pubkey = true
 public_key = "02d274968fe3b7f79074b9aad3221d71f42f4c0be9bb3a8e22e20396b9a63a847d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "02c031f6bc39053653a093d95511eb1197c5029c"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.234 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.234 }]
 
 [[puzzles]]
 bits = 235
-address = "1Pp61TfkztZ9ckpdeUVCzbyA7vMqXAVsdV"
+address = { value = "1Pp61TfkztZ9ckpdeUVCzbyA7vMqXAVsdV", kind = "p2pkh", hash160 = "fa3a7f736604e038a0a7fe5945a114467baba159" }
 prize = 0.235
 status = "swept"
 has_pubkey = true
 public_key = "02df2647ed50cded7c031a702c72b5b09209e5fd4a48c7cee7bf847f88c85bf4bd"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "fa3a7f736604e038a0a7fe5945a114467baba159"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.235 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.235 }]
 
 [[puzzles]]
 bits = 236
-address = "1PytbQzRaf9eTpGax3c6ofKwtbxaLLSNy1"
+address = { value = "1PytbQzRaf9eTpGax3c6ofKwtbxaLLSNy1", kind = "p2pkh", hash160 = "fc152109a2102e72ae6aca2192065e909170d2c3" }
 prize = 0.236
 status = "swept"
 has_pubkey = true
 public_key = "03e8c806fd610232c5b68d824b3a284e213e523492657965073c54ccaa8a58e8c6"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "fc152109a2102e72ae6aca2192065e909170d2c3"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.236 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.236 }]
 
 [[puzzles]]
 bits = 237
-address = "194bRtNQVRq4xi26UJZYTHexvLXijpzp3e"
+address = { value = "194bRtNQVRq4xi26UJZYTHexvLXijpzp3e", kind = "p2pkh", hash160 = "586efe7cb41fc58c651225492e5c706a3af15d35" }
 prize = 0.237
 status = "swept"
 has_pubkey = true
 public_key = "0288bc8b2d55ebc48d906478e7c37a78899632543dce63e6a9330a0a0c933e2095"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "586efe7cb41fc58c651225492e5c706a3af15d35"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.237 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.237 }]
 
 [[puzzles]]
 bits = 238
-address = "1DxBvzRMdvzop21DhnDJv4xJDYFGVtu7KZ"
+address = { value = "1DxBvzRMdvzop21DhnDJv4xJDYFGVtu7KZ", kind = "p2pkh", hash160 = "8e11830db460be44112d0d0150016fed31172246" }
 prize = 0.238
 status = "swept"
 has_pubkey = true
 public_key = "039a1c77eb960be561f622d14ad0de0d2660245e629c1b11033f769aec28270b77"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "8e11830db460be44112d0d0150016fed31172246"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.238 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.238 }]
 
 [[puzzles]]
 bits = 239
-address = "1QLHLvM6XKwygyWqo2cCPbfbf6woZzGEKH"
+address = { value = "1QLHLvM6XKwygyWqo2cCPbfbf6woZzGEKH", kind = "p2pkh", hash160 = "fff0706a3d7d599d40406165ad0daaa0fe9dfc9f" }
 prize = 0.239
 status = "swept"
 has_pubkey = true
 public_key = "02dd983a8c8c8c25d3a16b014ad3e09b8188a3dc0333fc3d4b1504b1d3013b344e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "fff0706a3d7d599d40406165ad0daaa0fe9dfc9f"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.239 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.239 }]
 
 [[puzzles]]
 bits = 240
-address = "1C8Hw6T5jypz92cNFr9Lkx4Xmr4DtP7zGA"
+address = { value = "1C8Hw6T5jypz92cNFr9Lkx4Xmr4DtP7zGA", kind = "p2pkh", hash160 = "7a0a6e15efc2350d3dd45b88d855062a810ca619" }
 prize = 0.24
 status = "swept"
 has_pubkey = true
 public_key = "03d569cafd2c67ce649d9b3484ae8cd392ad7019f0b7963fac095912d545070466"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "7a0a6e15efc2350d3dd45b88d855062a810ca619"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.24 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.24 }]
 
 [[puzzles]]
 bits = 241
-address = "1L7ZNx5gFPvdVPfdgFBnEUgA64woQwopqr"
+address = { value = "1L7ZNx5gFPvdVPfdgFBnEUgA64woQwopqr", kind = "p2pkh", hash160 = "d1a7e9f072b3ebc159327bec2f9ed46362a85bc9" }
 prize = 0.241
 status = "swept"
 has_pubkey = true
 public_key = "03fbf9615ddcc9c0c9e88fb69ed62465ba694f4694f0ea94a7f3476dbf666ba56d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "d1a7e9f072b3ebc159327bec2f9ed46362a85bc9"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.241 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.241 }]
 
 [[puzzles]]
 bits = 242
-address = "1EMhTbC4Kp8DYBk5zoLsTqZ2YakhiTgQYh"
+address = { value = "1EMhTbC4Kp8DYBk5zoLsTqZ2YakhiTgQYh", kind = "p2pkh", hash160 = "9283ba38d0bb048fb69d6aafc9a32b666f1c0977" }
 prize = 0.242
 status = "swept"
 has_pubkey = true
 public_key = "0387d4589510248cb352b5c82d7ee75454c507574cb281042eaf5dee2547abd2b2"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "9283ba38d0bb048fb69d6aafc9a32b666f1c0977"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.242 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.242 }]
 
 [[puzzles]]
 bits = 243
-address = "19CqmBBJ3H8FjxSSeSjv2Kn1cVQFXMY6AM"
+address = { value = "19CqmBBJ3H8FjxSSeSjv2Kn1cVQFXMY6AM", kind = "p2pkh", hash160 = "59fe4938c08cfa18b39d68a376ed2c065a98a55a" }
 prize = 0.243
 status = "swept"
 has_pubkey = true
 public_key = "0243609cd608d2d4744f3b11ff57875067ff2ac9966b87edc24e2daf2c784fc97d"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "59fe4938c08cfa18b39d68a376ed2c065a98a55a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.243 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.243 }]
 
 [[puzzles]]
 bits = 244
-address = "1KMHDrCGho2QuK59UNvfjuiPdDZSgRbneC"
+address = { value = "1KMHDrCGho2QuK59UNvfjuiPdDZSgRbneC", kind = "p2pkh", hash160 = "c9481fd7d3d294113c5e53990d9451e32844c0ec" }
 prize = 0.244
 status = "swept"
 has_pubkey = true
 public_key = "02eaa8294f7cba1ddf4a990032a2a6d9f07eef4309ab1a27a3446f591efe189314"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "c9481fd7d3d294113c5e53990d9451e32844c0ec"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.244 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.244 }]
 
 [[puzzles]]
 bits = 245
-address = "1HzpmnHxpu4tCJ23ZS9TfWCoX8mXfpdHiq"
+address = { value = "1HzpmnHxpu4tCJ23ZS9TfWCoX8mXfpdHiq", kind = "p2pkh", hash160 = "ba7199b9bcac99a8ee39e6f103ab3cb049e7dd86" }
 prize = 0.245
 status = "swept"
 has_pubkey = true
 public_key = "03c763aeffae32371612f8585c10710aaf7bf4a211a632c8a18b969a4f4e42db54"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "ba7199b9bcac99a8ee39e6f103ab3cb049e7dd86"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.245 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.245 }]
 
 [[puzzles]]
 bits = 246
-address = "1LrrNP28PYg1N1z5Uo1gR8cmoPc8h4orBZ"
+address = { value = "1LrrNP28PYg1N1z5Uo1gR8cmoPc8h4orBZ", kind = "p2pkh", hash160 = "d9d7fb9cf1d10075b0515591e2570c7efabc80c1" }
 prize = 0.246
 status = "swept"
 has_pubkey = true
 public_key = "0396ba2cc3d83caad1a3970670557417e627b7cf32ba4e6219604f8f5e7ca09752"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "d9d7fb9cf1d10075b0515591e2570c7efabc80c1"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.246 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.246 }]
 
 [[puzzles]]
 bits = 247
-address = "14D2d3WnHThUxyPhGoj2AabBTxpZcoHy3t"
+address = { value = "14D2d3WnHThUxyPhGoj2AabBTxpZcoHy3t", kind = "p2pkh", hash160 = "232eb8ef367fc06217fbaa43848df87567b2696d" }
 prize = 0.247
 status = "swept"
 has_pubkey = true
 public_key = "03c3f97e2896f15b0dbe0dcf12fe9ef3d62af375d683a4a93761d3f31785971dd3"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "232eb8ef367fc06217fbaa43848df87567b2696d"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.247 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.247 }]
 
 [[puzzles]]
 bits = 248
-address = "18oqrdP6uBKsn57gvmWzLuKMAY4ShapiAU"
+address = { value = "18oqrdP6uBKsn57gvmWzLuKMAY4ShapiAU", kind = "p2pkh", hash160 = "55a4cc2020c1769dce6c05e560bcff5db9f27f3a" }
 prize = 0.248
 status = "swept"
 has_pubkey = true
 public_key = "031037fc1784819309a913864372322768fee8ba8c3d3bf0566936096dab4157db"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "55a4cc2020c1769dce6c05e560bcff5db9f27f3a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.248 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.248 }]
 
 [[puzzles]]
 bits = 249
-address = "1Bun4VzuBJ7SUoQn97dinVfDyWAS336Ldg"
+address = { value = "1Bun4VzuBJ7SUoQn97dinVfDyWAS336Ldg", kind = "p2pkh", hash160 = "77ac8098d4726a592aed489e3880c23cfaf719ae" }
 prize = 0.249
 status = "swept"
 has_pubkey = true
 public_key = "02d1d5728abc050fc1c5fefc276616e50573139f89fdd01ac4ce2e52a19f945f8c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "77ac8098d4726a592aed489e3880c23cfaf719ae"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.249 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.249 }]
 
 [[puzzles]]
 bits = 250
-address = "1Ruu3JwvGeSmhQV9GzWAnyLCz6g3evmTY"
+address = { value = "1Ruu3JwvGeSmhQV9GzWAnyLCz6g3evmTY", kind = "p2pkh", hash160 = "04b623b48cc42741d0c9ec3b1fa297664bcec49b" }
 prize = 0.25
 status = "swept"
 has_pubkey = true
 public_key = "0230465312b31af6b26c64d58ebc8a890c41f52f57a5c0eb305d83b0351c4bf968"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "04b623b48cc42741d0c9ec3b1fa297664bcec49b"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.25 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.25 }]
 
 [[puzzles]]
 bits = 251
-address = "1M3u4q5Q35qtQPmDHeubVbk7APYi3VVoBX"
+address = { value = "1M3u4q5Q35qtQPmDHeubVbk7APYi3VVoBX", kind = "p2pkh", hash160 = "dbeecf6406c1569a483a88e35ed349a521a414ca" }
 prize = 0.251
 status = "swept"
 has_pubkey = true
 public_key = "02ec2ca969860c67210de88b622f37fd4c02488d8ff9cc879ae91405523724eb0e"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "dbeecf6406c1569a483a88e35ed349a521a414ca"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.251 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.251 }]
 
 [[puzzles]]
 bits = 252
-address = "1CaTxB3YwmXZkDnTK4rRvq61SRqs48xmui"
+address = { value = "1CaTxB3YwmXZkDnTK4rRvq61SRqs48xmui", kind = "p2pkh", hash160 = "7efd9baf1d6e21bd5f920e7e9e468b5a45ec92c7" }
 prize = 0.252
 status = "swept"
 has_pubkey = true
 public_key = "0316bbf51b1574f580cd5ec84fe2371b4fd5644637b713f3a795474a1be794001c"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "7efd9baf1d6e21bd5f920e7e9e468b5a45ec92c7"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.252 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.252 }]
 
 [[puzzles]]
 bits = 253
-address = "1JqRqUPHHcQu2yrr8JZzxSYDx2jbZxEqFj"
+address = { value = "1JqRqUPHHcQu2yrr8JZzxSYDx2jbZxEqFj", kind = "p2pkh", hash160 = "c3a2d618736baf0d5df7d81d5b8235cf8a266448" }
 prize = 0.253
 status = "swept"
 has_pubkey = true
 public_key = "0322ae607614dedc7261f4214dada55f1a0f11926174c3bf1689351c1783f3da48"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "c3a2d618736baf0d5df7d81d5b8235cf8a266448"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.253 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.253 }]
 
 [[puzzles]]
 bits = 254
-address = "1NKkjFvXmovmjwgUujw655n3BbEvnncyza"
+address = { value = "1NKkjFvXmovmjwgUujw655n3BbEvnncyza", kind = "p2pkh", hash160 = "e9e6a1ad0ddaf3c372e2e1eae83c8cf9f9163b3a" }
 prize = 0.254
 status = "swept"
 has_pubkey = true
 public_key = "0255d81444d53e97bf282ed8c505a686ca08d270493404c1db86e64b9494ee36cf"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "e9e6a1ad0ddaf3c372e2e1eae83c8cf9f9163b3a"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.254 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.254 }]
 
 [[puzzles]]
 bits = 255
-address = "17PEUvQmgqPkkvRkMowoR1wRDXYzre4b9Z"
+address = { value = "17PEUvQmgqPkkvRkMowoR1wRDXYzre4b9Z", kind = "p2pkh", hash160 = "460528d920ce045d9f6fc319182960707b248064" }
 prize = 0.255
 status = "swept"
 has_pubkey = true
 public_key = "030cea4a0ee0a03b7a5f77b85bb455b10979c2220f0e470ce5e0d4e0c786c04f66"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "460528d920ce045d9f6fc319182960707b248064"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.255 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.255 }]
 
 [[puzzles]]
 bits = 256
-address = "1FMcotmnqqE5M2x9DDX3VfPAPuBWArGisa"
+address = { value = "1FMcotmnqqE5M2x9DDX3VfPAPuBWArGisa", kind = "p2pkh", hash160 = "9d77f8bcfd56b6a095703aae85bbe003a9cff5eb" }
 prize = 0.256
 status = "swept"
 has_pubkey = true
 public_key = "029125aed5e5342de7c6163a4158a716ac982ba7d2ed85835c6ff99c68702ce710"
 pubkey_format = "compressed"
 start_date = "2015-01-15 18:07:14"
-h160 = "9d77f8bcfd56b6a095703aae85bbe003a9cff5eb"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.256 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.256 }]

--- a/data/gsmg.toml
+++ b/data/gsmg.toml
@@ -10,11 +10,10 @@ profile = "https://gsmg.io/puzzle"
 source_url = "https://gsmg.io/puzzle"
 
 [puzzle]
-address = "1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe"
+address = { value = "1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe", kind = "p2pkh", hash160 = "a9553269572a317e39f0f518cb87c1a0ee1dbae4" }
 status = "unsolved"
 prize = 1.25364181
 public_key = "04f4d1bbd91e65e2a019566a17574e97dae908b784b388891848007e4f55d5a4649c73d25fc5ed8fd7227cab0be4e576c0c6404db5aa546286563e4be12bf33559"
 pubkey_format = "uncompressed"
 start_date = "2019-04-13 16:32:40"
-h160 = "a9553269572a317e39f0f518cb87c1a0ee1dbae4"
 transactions = [{ type = "funding", txid = "73e48ff571a7e9a4387574a50cf2fcb7b21b6ea5702c777a035664df57cbce02", date = "2019-04-13 16:32:40", amount = 5.0 }, { type = "decrease", txid = "2aa9a4a90be819d5122d70c993280785a0508f163521e7b38cebb4db0b071b13", date = "2020-05-11 20:02:50", amount = 2.5 }, { type = "decrease", txid = "88cdb3cdca12b471551b1b26188508a14ca5fd8a415223ffb7c190381c9b9df3", date = "2024-04-24 21:47:27", amount = 1.25 }]

--- a/data/hash_collision.toml
+++ b/data/hash_collision.toml
@@ -8,7 +8,7 @@ source_url = "https://bitcointalk.org/index.php?topic=293382.0"
 
 [[puzzles]]
 name = "sha1"
-address = "37k7toV1Nv4DfmQbmZ8KuZDQCYK9x5KpzP"
+address = { value = "37k7toV1Nv4DfmQbmZ8KuZDQCYK9x5KpzP", kind = "p2sh" }
 status = "claimed"
 redeem_script = "6e879169a77ca787"
 prize = 2.48
@@ -20,7 +20,7 @@ transactions = [{ type = "funding", txid = "09de8e2de5f6261af40c522c8fcc008c6a83
 
 [[puzzles]]
 name = "sha256"
-address = "35Snmmy3uhaer2gTboc81ayCip4m9DT4ko"
+address = { value = "35Snmmy3uhaer2gTboc81ayCip4m9DT4ko", kind = "p2sh" }
 status = "unsolved"
 redeem_script = "6e879169a87ca887"
 prize = 0.27734251
@@ -30,7 +30,7 @@ transactions = [{ type = "funding", txid = "397f12ee15f8a3d2ab25c0f6bb7d3c64d203
 
 [[puzzles]]
 name = "ripemd160"
-address = "3KyiQEGqqdb4nqfhUzGKN6KPhXmQsLNpay"
+address = { value = "3KyiQEGqqdb4nqfhUzGKN6KPhXmQsLNpay", kind = "p2sh" }
 status = "unsolved"
 redeem_script = "6e879169a67ca687"
 prize = 0.11576888
@@ -40,7 +40,7 @@ transactions = [{ type = "funding", txid = "397f12ee15f8a3d2ab25c0f6bb7d3c64d203
 
 [[puzzles]]
 name = "hash160"
-address = "39VXyuoc6SXYKp9TcAhoiN1mb4ns6z3Yu6"
+address = { value = "39VXyuoc6SXYKp9TcAhoiN1mb4ns6z3Yu6", kind = "p2sh" }
 status = "unsolved"
 redeem_script = "6e879169a97ca987"
 prize = 0.10026873
@@ -50,7 +50,7 @@ transactions = [{ type = "funding", txid = "397f12ee15f8a3d2ab25c0f6bb7d3c64d203
 
 [[puzzles]]
 name = "hash256"
-address = "3DUQQvz4t57Jy7jxE86kyFcNpKtURNf1VW"
+address = { value = "3DUQQvz4t57Jy7jxE86kyFcNpKtURNf1VW", kind = "p2sh" }
 status = "unsolved"
 redeem_script = "6e879169aa7caa87"
 prize = 0.10026873
@@ -60,7 +60,7 @@ transactions = [{ type = "funding", txid = "397f12ee15f8a3d2ab25c0f6bb7d3c64d203
 
 [[puzzles]]
 name = "op_abs"
-address = "3QsT6Sast6ghfsjZ9VJj9u8jkM2qTfDgHV"
+address = { value = "3QsT6Sast6ghfsjZ9VJj9u8jkM2qTfDgHV", kind = "p2sh" }
 status = "claimed"
 redeem_script = "6e879169907c9087"
 solve_date = "2018-05-15 00:40:36"

--- a/data/zden.toml
+++ b/data/zden.toml
@@ -15,8 +15,7 @@ source_url = "https://crypto.haluska.sk/"
 [[puzzles]]
 name = "Level 1"
 chain = "bitcoin"
-address = "1cryptommoqPHVNHuxVQG3bzujnRJYB1D"
-h160 = "06c84797d2e333a2e692bb1c248f2cb20be50852"
+address = { value = "1cryptommoqPHVNHuxVQG3bzujnRJYB1D", kind = "p2pkh", hash160 = "06c84797d2e333a2e692bb1c248f2cb20be50852" }
 status = "solved"
 prize = 0.0260414
 start_date = "2016-06-07 23:05:42"
@@ -30,8 +29,7 @@ transactions = [
 [[puzzles]]
 name = "Level 2"
 chain = "bitcoin"
-address = "1cryptoTuax4qeedzVC35eYf4c16v4reJ"
-h160 = "06c84797d2819c984eb9045c1510b0e4fe8d7bf0"
+address = { value = "1cryptoTuax4qeedzVC35eYf4c16v4reJ", kind = "p2pkh", hash160 = "06c84797d2819c984eb9045c1510b0e4fe8d7bf0" }
 status = "solved"
 prize = 0.0260414
 start_date = "2016-06-16 17:14:33"
@@ -45,8 +43,7 @@ transactions = [
 [[puzzles]]
 name = "Level 3"
 chain = "bitcoin"
-address = "1cryptoJzomVVJUSys8Qv1gKPCXFoZy1U"
-h160 = "06c84797d250f130abafce9eafefea3f425e162e"
+address = { value = "1cryptoJzomVVJUSys8Qv1gKPCXFoZy1U", kind = "p2pkh", hash160 = "06c84797d250f130abafce9eafefea3f425e162e" }
 status = "solved"
 prize = 0.0260414
 start_date = "2016-06-23 18:37:33"
@@ -60,8 +57,7 @@ transactions = [
 [[puzzles]]
 name = "Level 4"
 chain = "bitcoin"
-address = "1cryptoRMRnj7Q9fgToxTRvejLnx3QRPq"
-h160 = "06c84797d273a88bcbcf0a98fd675aeae0447b56"
+address = { value = "1cryptoRMRnj7Q9fgToxTRvejLnx3QRPq", kind = "p2pkh", hash160 = "06c84797d273a88bcbcf0a98fd675aeae0447b56" }
 status = "solved"
 prize = 0.0260414
 start_date = "2017-06-07 14:39:28"
@@ -75,8 +71,7 @@ transactions = [
 [[puzzles]]
 name = "Level 5"
 chain = "bitcoin"
-address = "1cryptoGeCRiTzVgxBQcKFFjSVydN1GW7"
-h160 = "06c84797d2441393513e2169338e00cf2e755c8c"
+address = { value = "1cryptoGeCRiTzVgxBQcKFFjSVydN1GW7", kind = "p2pkh", hash160 = "06c84797d2441393513e2169338e00cf2e755c8c" }
 status = "unsolved"
 prize = 0.00620688
 start_date = "2018-10-20 20:40:17"
@@ -90,8 +85,7 @@ transactions = [
 [[puzzles]]
 name = "Level HALV"
 chain = "bitcoin"
-address = "1crypto24HCr178iMcKd5iUi5D4rsg1nK"
-h160 = "06c84797d1f468b9d5773a61c80073b344df7470"
+address = { value = "1crypto24HCr178iMcKd5iUi5D4rsg1nK", kind = "p2pkh", hash160 = "06c84797d1f468b9d5773a61c80073b344df7470" }
 status = "unsolved"
 prize = 0.003125
 start_date = "2024-04-18 11:19:41"
@@ -103,8 +97,7 @@ transactions = [
 [[puzzles]]
 name = "Level SFX"
 chain = "bitcoin"
-address = "1crypto92aYKxdzD6VSAKwpEJnXcA2s9t"
-h160 = "06c84797d21a7c43dce76bf6f510114560d6a135"
+address = { value = "1crypto92aYKxdzD6VSAKwpEJnXcA2s9t", kind = "p2pkh", hash160 = "06c84797d21a7c43dce76bf6f510114560d6a135" }
 status = "solved"
 prize = 0.00140426
 start_date = "2021-02-07 22:51:18"
@@ -119,8 +112,7 @@ transactions = [
 [[puzzles]]
 name = "Level XM17"
 chain = "bitcoin"
-address = "1cryptozWJAE7UzDZF1eSgsT7mVjUsu7g"
-h160 = "06c84797d328c065190a6768e20a84b7a17916c0"
+address = { value = "1cryptozWJAE7UzDZF1eSgsT7mVjUsu7g", kind = "p2pkh", hash160 = "06c84797d328c065190a6768e20a84b7a17916c0" }
 status = "solved"
 prize = 0.0260414
 start_date = "2017-12-24 09:50:13"
@@ -135,8 +127,7 @@ transactions = [
 [[puzzles]]
 name = "1BiTCoiN WHiTe PaPeR"
 chain = "bitcoin"
-address = "1BiTCoiNsuFnkCFGkv6AGgwWxN31GUwY6W"
-h160 = "75882f9639449778bb4cc2d242ed35dd2cca6f3e"
+address = { value = "1BiTCoiNsuFnkCFGkv6AGgwWxN31GUwY6W", kind = "p2pkh", hash160 = "75882f9639449778bb4cc2d242ed35dd2cca6f3e" }
 status = "solved"
 prize = 0.00117578
 start_date = "2021-04-11 01:59:51"
@@ -151,8 +142,7 @@ transactions = [
 [[puzzles]]
 name = "Demobit 2018"
 chain = "bitcoin"
-address = "1cryptotnptVK1ZbpZFyEqcR5EVp5hjfk"
-h160 = "06c84797d30988bc82a337117d02d7c4347fd35b"
+address = { value = "1cryptotnptVK1ZbpZFyEqcR5EVp5hjfk", kind = "p2pkh", hash160 = "06c84797d30988bc82a337117d02d7c4347fd35b" }
 status = "solved"
 prize = 0.01500245
 start_date = "2018-03-22 09:34:29"
@@ -167,8 +157,7 @@ transactions = [
 [[puzzles]]
 name = "Nethemba"
 chain = "bitcoin"
-address = "1cryptoP5yMdKcz1bjzUqnbs3LsasVRX6"
-h160 = "06c84797d267472edfe262ab43b2d6844e8bac9b"
+address = { value = "1cryptoP5yMdKcz1bjzUqnbs3LsasVRX6", kind = "p2pkh", hash160 = "06c84797d267472edfe262ab43b2d6844e8bac9b" }
 status = "solved"
 prize = 0.192018
 start_date = "2016-08-06 12:45:26"
@@ -185,7 +174,7 @@ transactions = [
 [[puzzles]]
 name = "XIXOIO"
 chain = "ethereum"
-address = "0x5d663791e869ca70c71e0a5f4cfd707f596265aa"
+address = { value = "0x5d663791e869ca70c71e0a5f4cfd707f596265aa", kind = "standard" }
 status = "solved"
 prize = 6.0
 start_date = "2018-10-24 20:00:18"
@@ -200,7 +189,7 @@ transactions = [
 [[puzzles]]
 name = "Codex Protocol"
 chain = "ethereum"
-address = "0x6b2560b34c7469c561a8fce581c88bfb8cce73b2"
+address = { value = "0x6b2560b34c7469c561a8fce581c88bfb8cce73b2", kind = "standard" }
 status = "solved"
 prize = 3.1337
 start_date = "2018-04-16 22:39:45"
@@ -217,8 +206,7 @@ transactions = [
 [[puzzles]]
 name = "Litecoin SegWit"
 chain = "litecoin"
-address = "LartGjF6UjmvmF1JXBhFf5wtM9uZX7LzeS"
-h160 = "ab85f21bf9ca1126f3776f4686cf02737be7a2b7"
+address = { value = "LartGjF6UjmvmF1JXBhFf5wtM9uZX7LzeS", kind = "p2pkh", hash160 = "ab85f21bf9ca1126f3776f4686cf02737be7a2b7" }
 status = "solved"
 prize = 230.8255
 start_date = "2017-05-10 05:46:11"
@@ -240,7 +228,7 @@ transactions = [
 [[puzzles]]
 name = "Decred Janus"
 chain = "decred"
-address = "DsRaAja82UvgnqYaBHYFuyCKURFX2rCyEJ8"
+address = { value = "DsRaAja82UvgnqYaBHYFuyCKURFX2rCyEJ8", kind = "p2pkh" }
 status = "solved"
 prize = 460.0
 start_date = "2017-03-07 05:20:56"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,7 +127,7 @@ impl PuzzleTableRow {
         Self {
             id: p.id.to_string(),
             chain: p.chain.symbol().to_string(),
-            address: p.address.to_string(),
+            address: p.address.value.to_string(),
             status,
             prize,
             solve_time,
@@ -369,14 +369,14 @@ fn print_puzzle_detail_table(p: &Puzzle, show_transactions: bool) {
         },
         KeyValueRow {
             field: "Address".to_string(),
-            value: p.address.to_string(),
+            value: p.address.value.to_string(),
         },
     ];
 
-    if let Some(h160) = p.h160 {
+    if let Some(hash160) = p.address.hash160 {
         rows.push(KeyValueRow {
-            field: "H160".to_string(),
-            value: h160.to_string(),
+            field: "HASH160".to_string(),
+            value: hash160.to_string(),
         });
     }
 
@@ -722,7 +722,7 @@ fn cmd_range(puzzle_number: u32, format: OutputFormat) {
                 puzzle: puzzle_number,
                 start: format!("0x{:x}", start),
                 end: format!("0x{:x}", end),
-                address: Some(p.address.to_string()),
+                address: Some(p.address.value.to_string()),
                 pubkey: p.pubkey.map(|pk| pk.key.to_string()),
             };
             output_range(&range, format);
@@ -804,10 +804,10 @@ fn print_author_table(author: &Author) {
 #[cfg(feature = "balance")]
 async fn cmd_balance(id: &str, format: OutputFormat) {
     match boha::get(id) {
-        Ok(puzzle) => match boha::balance::fetch(puzzle.address).await {
+        Ok(puzzle) => match boha::balance::fetch(puzzle.address.value).await {
             Ok(bal) => {
                 let output = BalanceOutput {
-                    address: puzzle.address.to_string(),
+                    address: puzzle.address.value.to_string(),
                     confirmed: bal.confirmed,
                     confirmed_btc: bal.confirmed_btc(),
                     unconfirmed: bal.unconfirmed,

--- a/src/collections/b1000.rs
+++ b/src/collections/b1000.rs
@@ -4,8 +4,8 @@
 
 #[allow(unused_imports)]
 use crate::{
-    AddressType, Author, Chain, Error, IntoPuzzleNum, KeySource, Pubkey, PubkeyFormat, Puzzle,
-    Result, Solver, Status, Transaction, TransactionType,
+    Address, Author, Chain, Error, IntoPuzzleNum, KeySource, Pubkey, PubkeyFormat, Puzzle, Result,
+    Solver, Status, Transaction, TransactionType,
 };
 
 include!(concat!(env!("OUT_DIR"), "/b1000_data.rs"));

--- a/src/collections/gsmg.rs
+++ b/src/collections/gsmg.rs
@@ -2,8 +2,8 @@
 
 #[allow(unused_imports)]
 use crate::{
-    AddressType, Author, Chain, KeySource, Pubkey, PubkeyFormat, Puzzle, Solver, Status,
-    Transaction, TransactionType,
+    Address, Author, Chain, KeySource, Pubkey, PubkeyFormat, Puzzle, Solver, Status, Transaction,
+    TransactionType,
 };
 
 include!(concat!(env!("OUT_DIR"), "/gsmg_data.rs"));

--- a/src/collections/hash_collision.rs
+++ b/src/collections/hash_collision.rs
@@ -2,7 +2,7 @@
 
 #[allow(unused_imports)]
 use crate::{
-    AddressType, Author, Chain, Error, KeySource, Puzzle, Result, Solver, Status, Transaction,
+    Address, Author, Chain, Error, KeySource, Puzzle, Result, Solver, Status, Transaction,
     TransactionType,
 };
 

--- a/src/collections/zden.rs
+++ b/src/collections/zden.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use crate::{
-    Author, Chain, Error, KeySource, Puzzle, Result, Solver, Status, Transaction, TransactionType,
+    Address, Author, Chain, Error, KeySource, Puzzle, Result, Solver, Status, Transaction,
+    TransactionType,
 };
 
 include!(concat!(env!("OUT_DIR"), "/zden_data.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod balance;
 
 pub use collections::{b1000, gsmg, hash_collision, zden};
 pub use puzzle::{
-    AddressType, Author, Chain, IntoPuzzleNum, KeySource, Pubkey, PubkeyFormat, Puzzle, Solver,
-    Status, Transaction, TransactionType,
+    Address, Author, Chain, IntoPuzzleNum, KeySource, Pubkey, PubkeyFormat, Puzzle, Solver, Status,
+    Transaction, TransactionType,
 };
 
 use std::collections::HashMap;

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -85,7 +85,7 @@ impl Status {
 }
 
 /// Crypto address with chain-specific type information.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct Address {
     /// The address string (e.g., "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH")
     pub value: &'static str,

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -84,30 +84,17 @@ impl Status {
     }
 }
 
-/// Crypto address type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AddressType {
-    /// Pay to Public Key Hash (1...)
-    P2PKH,
-    /// Pay to Script Hash (3...)
-    P2SH,
-    /// Pay to Witness Public Key Hash (bc1q...)
-    P2WPKH,
-}
-
-impl AddressType {
-    pub fn from_address(address: &str) -> Option<Self> {
-        if address.starts_with('1') {
-            Some(AddressType::P2PKH)
-        } else if address.starts_with('3') {
-            Some(AddressType::P2SH)
-        } else if address.starts_with("bc1q") {
-            Some(AddressType::P2WPKH)
-        } else {
-            None
-        }
-    }
+/// Crypto address with chain-specific type information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Address {
+    /// The address string (e.g., "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH")
+    pub value: &'static str,
+    /// Blockchain network
+    pub chain: Chain,
+    /// Address type/kind (e.g., "p2pkh", "p2sh", "standard")
+    pub kind: &'static str,
+    /// HASH160 of the public key (SHA256 + RIPEMD160, for P2PKH addresses)
+    pub hash160: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -171,9 +158,7 @@ pub struct Pubkey {
 pub struct Puzzle {
     pub id: &'static str,
     pub chain: Chain,
-    pub address: &'static str,
-    pub address_type: Option<AddressType>,
-    pub h160: Option<&'static str>,
+    pub address: Address,
     pub status: Status,
     pub pubkey: Option<Pubkey>,
     pub private_key: Option<&'static str>,
@@ -355,22 +340,6 @@ impl IntoPuzzleNum for String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_address_type_detection() {
-        assert_eq!(
-            AddressType::from_address("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH"),
-            Some(AddressType::P2PKH)
-        );
-        assert_eq!(
-            AddressType::from_address("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"),
-            Some(AddressType::P2SH)
-        );
-        assert_eq!(
-            AddressType::from_address("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"),
-            Some(AddressType::P2WPKH)
-        );
-    }
 
     #[test]
     fn test_status_is_active() {


### PR DESCRIPTION
## Summary

Introduces a unified `Address` struct to consolidate address-related fields that were previously scattered across `Puzzle`. This provides a cleaner, more extensible foundation for multi-chain address handling.

Closes #54

## Changes

- **New `Address` struct** with fields: `value`, `chain`, `kind`, `hash160`
- **TOML structure** updated to nested format: `address = { value = "...", kind = "p2pkh", hash160 = "..." }`
- **Build-time validation**: Bitcoin/Litecoin addresses require `hash160`
- **Renamed `h160` → `hash160`** for clarity (HASH160 = SHA256 + RIPEMD160)
- **Removed `AddressType` enum** - replaced with flexible `kind: &'static str`

## API Changes

```rust
// Before
puzzle.address      // &str
puzzle.address_type // Option<AddressType>
puzzle.h160         // Option<&str>

// After
puzzle.address.value   // &str
puzzle.address.kind    // &str ("p2pkh", "p2sh", "standard")
puzzle.address.hash160 // Option<&str>
puzzle.chain           // still available directly for convenience
```

## Testing

- All 77 validation tests pass
- Clippy clean

---
Co-Authored-By: Aei <aei@oad.earth>