### PR TITLE
feat(zden): add private key for Level 1

### DIFF
--- a/data/zden.toml
+++ b/data/zden.toml
@@ -16,6 +16,9 @@ source_url = "https://crypto.haluska.sk/"
 name = "Level 1"
 chain = "bitcoin"
 address = { value = "1cryptommoqPHVNHuxVQG3bzujnRJYB1D", kind = "p2pkh", hash160 = "06c84797d2e333a2e692bb1c248f2cb20be50852" }
+public_key = "0408fe136fc5f5ab550da96673c050c539ce9877ec69965dde958d080cc4a2b896d6db9afd83e05875a401edcbc0e870c23251cb12b55677dba04a495806fd9fb7"
+pubkey_format = "uncompressed"
+key = { bits = 255, hex = "46c92e7276ae95778df0d7a248ab736cb6275190ded54438377a2e4b0d42a096", wif = { decrypted = "5JMTiDVHj3pj8VfaTe6pDtD9byZr6too3PD3AGBJrXF1hVsitc8" } }
 status = "solved"
 prize = 0.0260414
 start_date = "2016-06-07 21:05:42"

--- a/src/collections/zden.rs
+++ b/src/collections/zden.rs
@@ -1,7 +1,8 @@
 #[allow(unused_imports)]
 use crate::{
     Address, Assets, Author, Chain, Entropy, EntropySource, Error, Key, Passphrase, Profile,
-    Puzzle, RedeemScript, Result, Seed, Solver, Status, Transaction, TransactionType, Wif,
+    Pubkey, PubkeyFormat, Puzzle, RedeemScript, Result, Seed, Solver, Status, Transaction,
+    TransactionType, Wif,
 };
 
 include!(concat!(env!("OUT_DIR"), "/zden_data.rs"));


### PR DESCRIPTION
## Summary
Add the verified private key for zden Level 1 puzzle, which was marked as solved but missing key data.

Closes #80

## Changes
- Add private key: `5JMTiDVHj3pj8VfaTe6pDtD9byZr6too3PD3AGBJrXF1hVsitc8`
- Key details: 255 bits, uncompressed public key format
- Enable `pubkey` support in zden collection (build.rs + imports)
- Add build-time validation: `bits` field required when `hex` or `wif` exists

## Testing
- All 116 tests pass
- Key verified: hash160 matches address `1cryptommoqPHVNHuxVQG3bzujnRJYB1D`

---
Co-Authored-By: Aei <aei@oad.earth>