### PR TITLE
refactor(pubkey): rename key to value

### DIFF
--- a/data/b1000.toml
+++ b/data/b1000.toml
@@ -22,8 +22,7 @@ key = { bits = 1, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH", kind = "p2pkh", hash160 = "751e76e8199196d454941c45d1b3a323f1433bd6" }
 prize = 0.001
 status = "solved"
-public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
-pubkey_format = "compressed"
+pubkey = { value = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", format = "compressed" }
 solve_date = "2013-01-10 02:54:44"
 start_date = "2013-01-09 11:59:15"
 solve_time = 53729
@@ -36,8 +35,7 @@ key = { bits = 2, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb", kind = "p2pkh", hash160 = "7dd65592d0ab2fe0d0257d571abf032cd9db93dc" }
 prize = 0.002
 status = "solved"
-public_key = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
-pubkey_format = "compressed"
+pubkey = { value = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2014-07-29 21:53:54"
 solve_time = 14674400
@@ -49,8 +47,7 @@ key = { bits = 3, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "19ZewH8Kk1PDbSNdJ97FP4EiCjTRaZMZQA", kind = "p2pkh", hash160 = "5dedfbf9ea599dd4e3ca6a80b333c472fd0b3f69" }
 prize = 0.003
 status = "solved"
-public_key = "025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc"
-pubkey_format = "compressed"
+pubkey = { value = "025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -61,8 +58,7 @@ key = { bits = 4, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1EhqbyUMvvs7BfL8goY6qcPbD6YKfPqb7e", kind = "p2pkh", hash160 = "9652d86bedf43ad264362e6e6eba6eb764508127" }
 prize = 0.004
 status = "solved"
-public_key = "022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"
-pubkey_format = "compressed"
+pubkey = { value = "022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -73,8 +69,7 @@ key = { bits = 5, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1E6NuFjCi27W5zoXg8TRdcSRq84zJeBW3k", kind = "p2pkh", hash160 = "8f9dff39a81ee4abcbad2ad8bafff090415a2be8" }
 prize = 0.005
 status = "solved"
-public_key = "02352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5"
-pubkey_format = "compressed"
+pubkey = { value = "02352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -85,8 +80,7 @@ key = { bits = 6, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1PitScNLyp2HCygzadCh7FveTnfmpPbfp8", kind = "p2pkh", hash160 = "f93ec34e9e34a8f8ff7d600cdad83047b1bcb45c" }
 prize = 0.006
 status = "solved"
-public_key = "03f2dac991cc4ce4b9ea44887e5c7c0bce58c80074ab9d4dbaeb28531b7739f530"
-pubkey_format = "compressed"
+pubkey = { value = "03f2dac991cc4ce4b9ea44887e5c7c0bce58c80074ab9d4dbaeb28531b7739f530", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -97,8 +91,7 @@ key = { bits = 7, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1McVt1vMtCC7yn5b9wgX1833yCcLXzueeC", kind = "p2pkh", hash160 = "e2192e8a7dd8dd1c88321959b477968b941aa973" }
 prize = 0.007
 status = "solved"
-public_key = "0296516a8f65774275278d0d7420a88df0ac44bd64c7bae07c3fe397c5b3300b23"
-pubkey_format = "compressed"
+pubkey = { value = "0296516a8f65774275278d0d7420a88df0ac44bd64c7bae07c3fe397c5b3300b23", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -109,8 +102,7 @@ key = { bits = 8, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1M92tSqNmQLYw33fuBvjmeadirh1ysMBxK", kind = "p2pkh", hash160 = "dce76b2613052ea012204404a97b3c25eac31715" }
 prize = 0.008
 status = "solved"
-public_key = "0308bc89c2f919ed158885c35600844d49890905c79b357322609c45706ce6b514"
-pubkey_format = "compressed"
+pubkey = { value = "0308bc89c2f919ed158885c35600844d49890905c79b357322609c45706ce6b514", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -121,8 +113,7 @@ key = { bits = 9, hex = "0000000000000000000000000000000000000000000000000000000
 address = { value = "1CQFwcjw1dwhtkVWBttNLDtqL7ivBonGPV", kind = "p2pkh", hash160 = "7d0f6c64afb419bbd7e971e943d7404b0e0daab4" }
 prize = 0.009
 status = "solved"
-public_key = "0243601d61c836387485e9514ab5c8924dd2cfd466af34ac95002727e1659d60f7"
-pubkey_format = "compressed"
+pubkey = { value = "0243601d61c836387485e9514ab5c8924dd2cfd466af34ac95002727e1659d60f7", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -133,8 +124,7 @@ key = { bits = 10, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1LeBZP5QCwwgXRtmVUvTVrraqPUokyLHqe", kind = "p2pkh", hash160 = "d7729816650e581d7462d52ad6f732da0e2ec93b" }
 prize = 0.01
 status = "solved"
-public_key = "03a7a4c30291ac1db24b4ab00c442aa832f7794b5a0959bec6e8d7fee802289dcd"
-pubkey_format = "compressed"
+pubkey = { value = "03a7a4c30291ac1db24b4ab00c442aa832f7794b5a0959bec6e8d7fee802289dcd", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -145,8 +135,7 @@ key = { bits = 11, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1PgQVLmst3Z314JrQn5TNiys8Hc38TcXJu", kind = "p2pkh", hash160 = "f8c698da3164ef8fa4258692d118cc9a902c5acc" }
 prize = 0.011
 status = "solved"
-public_key = "038b05b0603abd75b0c57489e451f811e1afe54a8715045cdf4888333f3ebc6e8b"
-pubkey_format = "compressed"
+pubkey = { value = "038b05b0603abd75b0c57489e451f811e1afe54a8715045cdf4888333f3ebc6e8b", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -157,8 +146,7 @@ key = { bits = 12, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1DBaumZxUkM4qMQRt2LVWyFJq5kDtSZQot", kind = "p2pkh", hash160 = "85a1f9ba4da24c24e582d9b891dacbd1b043f971" }
 prize = 0.012
 status = "solved"
-public_key = "038b00fcbfc1a203f44bf123fc7f4c91c10a85c8eae9187f9d22242b4600ce781c"
-pubkey_format = "compressed"
+pubkey = { value = "038b00fcbfc1a203f44bf123fc7f4c91c10a85c8eae9187f9d22242b4600ce781c", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -169,8 +157,7 @@ key = { bits = 13, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1Pie8JkxBT6MGPz9Nvi3fsPkr2D8q3GBc1", kind = "p2pkh", hash160 = "f932d0188616c964416b91fb9cf76ba9790a921e" }
 prize = 0.013
 status = "solved"
-public_key = "03aadaaab1db8d5d450b511789c37e7cfeb0eb8b3e61a57a34166c5edc9a4b869d"
-pubkey_format = "compressed"
+pubkey = { value = "03aadaaab1db8d5d450b511789c37e7cfeb0eb8b3e61a57a34166c5edc9a4b869d", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -181,8 +168,7 @@ key = { bits = 14, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1ErZWg5cFCe4Vw5BzgfzB74VNLaXEiEkhk", kind = "p2pkh", hash160 = "97f9281a1383879d72ac52a6a3e9e8b9a4a4f655" }
 prize = 0.014
 status = "solved"
-public_key = "03b4f1de58b8b41afe9fd4e5ffbdafaeab86c5db4769c15d6e6011ae7351e54759"
-pubkey_format = "compressed"
+pubkey = { value = "03b4f1de58b8b41afe9fd4e5ffbdafaeab86c5db4769c15d6e6011ae7351e54759", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -193,8 +179,7 @@ key = { bits = 15, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1QCbW9HWnwQWiQqVo5exhAnmfqKRrCRsvW", kind = "p2pkh", hash160 = "fe7c45126731f7384640b0b0045fd40bac72e2a2" }
 prize = 0.015
 status = "solved"
-public_key = "02fea58ffcf49566f6e9e9350cf5bca2861312f422966e8db16094beb14dc3df2c"
-pubkey_format = "compressed"
+pubkey = { value = "02fea58ffcf49566f6e9e9350cf5bca2861312f422966e8db16094beb14dc3df2c", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -205,8 +190,7 @@ key = { bits = 16, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1BDyrQ6WoF8VN3g9SAS1iKZcPzFfnDVieY", kind = "p2pkh", hash160 = "7025b4efb3ff42eb4d6d71fab6b53b4f4967e3dd" }
 prize = 0.016
 status = "solved"
-public_key = "029d8c5d35231d75eb87fd2c5f05f65281ed9573dc41853288c62ee94eb2590b7a"
-pubkey_format = "compressed"
+pubkey = { value = "029d8c5d35231d75eb87fd2c5f05f65281ed9573dc41853288c62ee94eb2590b7a", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -217,8 +201,7 @@ key = { bits = 17, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1HduPEXZRdG26SUT5Yk83mLkPyjnZuJ7Bm", kind = "p2pkh", hash160 = "b67cb6edeabc0c8b927c9ea327628e7aa63e2d52" }
 prize = 0.017
 status = "solved"
-public_key = "033f688bae8321b8e02b7e6c0a55c2515fb25ab97d85fda842449f7bfa04e128c3"
-pubkey_format = "compressed"
+pubkey = { value = "033f688bae8321b8e02b7e6c0a55c2515fb25ab97d85fda842449f7bfa04e128c3", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -229,8 +212,7 @@ key = { bits = 18, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1GnNTmTVLZiqQfLbAdp9DVdicEnB5GoERE", kind = "p2pkh", hash160 = "ad1e852b08eba53df306ec9daa8c643426953f94" }
 prize = 0.018
 status = "solved"
-public_key = "020ce4a3291b19d2e1a7bf73ee87d30a6bdbc72b20771e7dfff40d0db755cd4af1"
-pubkey_format = "compressed"
+pubkey = { value = "020ce4a3291b19d2e1a7bf73ee87d30a6bdbc72b20771e7dfff40d0db755cd4af1", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -241,8 +223,7 @@ key = { bits = 19, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1NWmZRpHH4XSPwsW6dsS3nrNWfL1yrJj4w", kind = "p2pkh", hash160 = "ebfbe6819fcdebab061732ce91df7d586a037dee" }
 prize = 0.019
 status = "solved"
-public_key = "0385663c8b2f90659e1ccab201694f4f8ec24b3749cfe5030c7c3646a709408e19"
-pubkey_format = "compressed"
+pubkey = { value = "0385663c8b2f90659e1ccab201694f4f8ec24b3749cfe5030c7c3646a709408e19", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -253,8 +234,7 @@ key = { bits = 20, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1HsMJxNiV7TLxmoF6uJNkydxPFDog4NQum", kind = "p2pkh", hash160 = "b907c3a2a3b27789dfb509b730dd47703c272868" }
 prize = 0.02
 status = "solved"
-public_key = "033c4a45cbd643ff97d77f41ea37e843648d50fd894b864b0d52febc62f6454f7c"
-pubkey_format = "compressed"
+pubkey = { value = "033c4a45cbd643ff97d77f41ea37e843648d50fd894b864b0d52febc62f6454f7c", format = "compressed" }
 solve_date = "2015-01-15 18:07:14"
 start_date = "2015-01-15 18:07:14"
 solve_time = 0
@@ -265,8 +245,7 @@ key = { bits = 21, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "14oFNXucftsHiUMY8uctg6N487riuyXs4h", kind = "p2pkh", hash160 = "29a78213caa9eea824acf08022ab9dfc83414f56" }
 prize = 0.021
 status = "solved"
-public_key = "031a746c78f72754e0be046186df8a20cdce5c79b2eda76013c647af08d306e49e"
-pubkey_format = "compressed"
+pubkey = { value = "031a746c78f72754e0be046186df8a20cdce5c79b2eda76013c647af08d306e49e", format = "compressed" }
 solve_date = "2015-01-15 19:11:31"
 start_date = "2015-01-15 18:07:14"
 solve_time = 3857
@@ -277,8 +256,7 @@ key = { bits = 22, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1CfZWK1QTQE3eS9qn61dQjV89KDjZzfNcv", kind = "p2pkh", hash160 = "7ff45303774ef7a52fffd8011981034b258cb86b" }
 prize = 0.022
 status = "solved"
-public_key = "023ed96b524db5ff4fe007ce730366052b7c511dc566227d929070b9ce917abb43"
-pubkey_format = "compressed"
+pubkey = { value = "023ed96b524db5ff4fe007ce730366052b7c511dc566227d929070b9ce917abb43", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -289,8 +267,7 @@ key = { bits = 23, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1L2GM8eE7mJWLdo3HZS6su1832NX2txaac", kind = "p2pkh", hash160 = "d0a79df189fe1ad5c306cc70497b358415da579e" }
 prize = 0.023
 status = "solved"
-public_key = "03f82710361b8b81bdedb16994f30c80db522450a93e8e87eeb07f7903cf28d04b"
-pubkey_format = "compressed"
+pubkey = { value = "03f82710361b8b81bdedb16994f30c80db522450a93e8e87eeb07f7903cf28d04b", format = "compressed" }
 solve_date = "2015-01-15 19:11:31"
 start_date = "2015-01-15 18:07:14"
 solve_time = 3857
@@ -301,8 +278,7 @@ key = { bits = 24, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1rSnXMr63jdCuegJFuidJqWxUPV7AtUf7", kind = "p2pkh", hash160 = "0959e80121f36aea13b3bad361c15dac26189e2f" }
 prize = 0.024
 status = "solved"
-public_key = "036ea839d22847ee1dce3bfc5b11f6cf785b0682db58c35b63d1342eb221c3490c"
-pubkey_format = "compressed"
+pubkey = { value = "036ea839d22847ee1dce3bfc5b11f6cf785b0682db58c35b63d1342eb221c3490c", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -313,8 +289,7 @@ key = { bits = 25, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "15JhYXn6Mx3oF4Y7PcTAv2wVVAuCFFQNiP", kind = "p2pkh", hash160 = "2f396b29b27324300d0c59b17c3abc1835bd3dbb" }
 prize = 0.025
 status = "solved"
-public_key = "03057fbea3a2623382628dde556b2a0698e32428d3cd225f3bd034dca82dd7455a"
-pubkey_format = "compressed"
+pubkey = { value = "03057fbea3a2623382628dde556b2a0698e32428d3cd225f3bd034dca82dd7455a", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -325,8 +300,7 @@ key = { bits = 26, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1JVnST957hGztonaWK6FougdtjxzHzRMMg", kind = "p2pkh", hash160 = "bfebb73562d4541b32a02ba664d140b5a574792f" }
 prize = 0.026
 status = "solved"
-public_key = "024e4f50a2a3eccdb368988ae37cd4b611697b26b29696e42e06d71368b4f3840f"
-pubkey_format = "compressed"
+pubkey = { value = "024e4f50a2a3eccdb368988ae37cd4b611697b26b29696e42e06d71368b4f3840f", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -337,8 +311,7 @@ key = { bits = 27, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "128z5d7nN7PkCuX5qoA4Ys6pmxUYnEy86k", kind = "p2pkh", hash160 = "0c7aaf6caa7e5424b63d317f0f8f1f9fa40d5560" }
 prize = 0.027
 status = "solved"
-public_key = "031a864bae3922f351f1b57cfdd827c25b7e093cb9c88a72c1cd893d9f90f44ece"
-pubkey_format = "compressed"
+pubkey = { value = "031a864bae3922f351f1b57cfdd827c25b7e093cb9c88a72c1cd893d9f90f44ece", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -349,8 +322,7 @@ key = { bits = 28, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "12jbtzBb54r97TCwW3G1gCFoumpckRAPdY", kind = "p2pkh", hash160 = "1306b9e4ff56513a476841bac7ba48d69516b1da" }
 prize = 0.028
 status = "solved"
-public_key = "03e9e661838a96a65331637e2a3e948dc0756e5009e7cb5c36664d9b72dd18c0a7"
-pubkey_format = "compressed"
+pubkey = { value = "03e9e661838a96a65331637e2a3e948dc0756e5009e7cb5c36664d9b72dd18c0a7", format = "compressed" }
 solve_date = "2015-01-15 22:15:25"
 start_date = "2015-01-15 18:07:14"
 solve_time = 14891
@@ -361,8 +333,7 @@ key = { bits = 29, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "19EEC52krRUK1RkUAEZmQdjTyHT7Gp1TYT", kind = "p2pkh", hash160 = "5a416cc9148f4a377b672c8ae5d3287adaafadec" }
 prize = 0.029
 status = "solved"
-public_key = "026caad634382d34691e3bef43ed4a124d8909a8a3362f91f1d20abaaf7e917b36"
-pubkey_format = "compressed"
+pubkey = { value = "026caad634382d34691e3bef43ed4a124d8909a8a3362f91f1d20abaaf7e917b36", format = "compressed" }
 solve_date = "2015-01-16 02:46:38"
 start_date = "2015-01-15 18:07:14"
 solve_time = 31164
@@ -373,8 +344,7 @@ key = { bits = 30, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1LHtnpd8nU5VHEMkG2TMYYNUjjLc992bps", kind = "p2pkh", hash160 = "d39c4704664e1deb76c9331e637564c257d68a08" }
 prize = 0.03
 status = "solved"
-public_key = "030d282cf2ff536d2c42f105d0b8588821a915dc3f9a05bd98bb23af67a2e92a5b"
-pubkey_format = "compressed"
+pubkey = { value = "030d282cf2ff536d2c42f105d0b8588821a915dc3f9a05bd98bb23af67a2e92a5b", format = "compressed" }
 solve_date = "2015-01-16 13:31:58"
 start_date = "2015-01-15 18:07:14"
 solve_time = 69884
@@ -385,8 +355,7 @@ key = { bits = 31, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1LhE6sCTuGae42Axu1L1ZB7L96yi9irEBE", kind = "p2pkh", hash160 = "d805f6f251f7479ebd853b3d0f4b9b2656d92f1d" }
 prize = 0.031
 status = "solved"
-public_key = "0387dc70db1806cd9a9a76637412ec11dd998be666584849b3185f7f9313c8fd28"
-pubkey_format = "compressed"
+pubkey = { value = "0387dc70db1806cd9a9a76637412ec11dd998be666584849b3185f7f9313c8fd28", format = "compressed" }
 solve_date = "2015-01-16 08:02:15"
 start_date = "2015-01-15 18:07:14"
 solve_time = 50101
@@ -397,8 +366,7 @@ key = { bits = 32, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1FRoHA9xewq7DjrZ1psWJVeTer8gHRqEvR", kind = "p2pkh", hash160 = "9e42601eeaedc244e15f17375adb0e2cd08efdc9" }
 prize = 0.032
 status = "solved"
-public_key = "0209c58240e50e3ba3f833c82655e8725c037a2294e14cf5d73a5df8d56159de69"
-pubkey_format = "compressed"
+pubkey = { value = "0209c58240e50e3ba3f833c82655e8725c037a2294e14cf5d73a5df8d56159de69", format = "compressed" }
 solve_date = "2015-01-16 04:57:19"
 start_date = "2015-01-15 18:07:14"
 solve_time = 39005
@@ -409,8 +377,7 @@ key = { bits = 33, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "187swFMjz1G54ycVU56B7jZFHFTNVQFDiu", kind = "p2pkh", hash160 = "4e15e5189752d1eaf444dfd6bff399feb0443977" }
 prize = 0.033
 status = "solved"
-public_key = "03a355aa5e2e09dd44bb46a4722e9336e9e3ee4ee4e7b7a0cf5785b283bf2ab579"
-pubkey_format = "compressed"
+pubkey = { value = "03a355aa5e2e09dd44bb46a4722e9336e9e3ee4ee4e7b7a0cf5785b283bf2ab579", format = "compressed" }
 solve_date = "2015-01-16 16:43:28"
 start_date = "2015-01-15 18:07:14"
 solve_time = 81374
@@ -421,8 +388,7 @@ key = { bits = 34, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1PWABE7oUahG2AFFQhhvViQovnCr4rEv7Q", kind = "p2pkh", hash160 = "f6d67d7983bf70450f295c9cb828daab265f1bfa" }
 prize = 0.034
 status = "solved"
-public_key = "033cdd9d6d97cbfe7c26f902faf6a435780fe652e159ec953650ec7b1004082790"
-pubkey_format = "compressed"
+pubkey = { value = "033cdd9d6d97cbfe7c26f902faf6a435780fe652e159ec953650ec7b1004082790", format = "compressed" }
 solve_date = "2015-01-17 00:14:34"
 start_date = "2015-01-15 18:07:14"
 solve_time = 108440
@@ -433,8 +399,7 @@ key = { bits = 35, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1PWCx5fovoEaoBowAvF5k91m2Xat9bMgwb", kind = "p2pkh", hash160 = "f6d8ce225ffbdecec170f8298c3fc28ae686df25" }
 prize = 0.035
 status = "solved"
-public_key = "02f6a8148a62320e149cb15c544fe8a25ab483a0095d2280d03b8a00a7feada13d"
-pubkey_format = "compressed"
+pubkey = { value = "02f6a8148a62320e149cb15c544fe8a25ab483a0095d2280d03b8a00a7feada13d", format = "compressed" }
 solve_date = "2015-01-17 07:33:27"
 start_date = "2015-01-15 18:07:14"
 solve_time = 134773
@@ -445,8 +410,7 @@ key = { bits = 36, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1Be2UF9NLfyLFbtm3TCbmuocc9N1Kduci1", kind = "p2pkh", hash160 = "74b1e012be1521e5d8d75e745a26ced845ea3d37" }
 prize = 0.036
 status = "solved"
-public_key = "02b3e772216695845fa9dda419fb5daca28154d8aa59ea302f05e916635e47b9f6"
-pubkey_format = "compressed"
+pubkey = { value = "02b3e772216695845fa9dda419fb5daca28154d8aa59ea302f05e916635e47b9f6", format = "compressed" }
 solve_date = "2015-01-17 17:14:40"
 start_date = "2015-01-15 18:07:14"
 solve_time = 169646
@@ -457,8 +421,7 @@ key = { bits = 37, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "14iXhn8bGajVWegZHJ18vJLHhntcpL4dex", kind = "p2pkh", hash160 = "28c30fb9118ed1da72e7c4f89c0164756e8a021d" }
 prize = 0.037
 status = "solved"
-public_key = "027d2c03c3ef0aec70f2c7e1e75454a5dfdd0e1adea670c1b3a4643c48ad0f1255"
-pubkey_format = "compressed"
+pubkey = { value = "027d2c03c3ef0aec70f2c7e1e75454a5dfdd0e1adea670c1b3a4643c48ad0f1255", format = "compressed" }
 solve_date = "2015-01-18 23:32:11"
 start_date = "2015-01-15 18:07:14"
 solve_time = 278697
@@ -469,8 +432,7 @@ key = { bits = 38, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1HBtApAFA9B2YZw3G2YKSMCtb3dVnjuNe2", kind = "p2pkh", hash160 = "b190e2d40cfdeee2cee072954a2be89e7ba39364" }
 prize = 0.038
 status = "solved"
-public_key = "03c060e1e3771cbeccb38e119c2414702f3f5181a89652538851d2e3886bdd70c6"
-pubkey_format = "compressed"
+pubkey = { value = "03c060e1e3771cbeccb38e119c2414702f3f5181a89652538851d2e3886bdd70c6", format = "compressed" }
 solve_date = "2015-01-19 10:27:27"
 start_date = "2015-01-15 18:07:14"
 solve_time = 318013
@@ -481,8 +443,7 @@ key = { bits = 39, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "122AJhKLEfkFBaGAd84pLp1kfE7xK3GdT8", kind = "p2pkh", hash160 = "0b304f2a79a027270276533fe1ed4eff30910876" }
 prize = 0.039
 status = "solved"
-public_key = "022d77cd1467019a6bf28f7375d0949ce30e6b5815c2758b98a74c2700bc006543"
-pubkey_format = "compressed"
+pubkey = { value = "022d77cd1467019a6bf28f7375d0949ce30e6b5815c2758b98a74c2700bc006543", format = "compressed" }
 solve_date = "2015-01-21 06:35:26"
 start_date = "2015-01-15 18:07:14"
 solve_time = 476892
@@ -493,8 +454,7 @@ key = { bits = 40, hex = "000000000000000000000000000000000000000000000000000000
 address = { value = "1EeAxcprB2PpCnr34VfZdFrkUWuxyiNEFv", kind = "p2pkh", hash160 = "95a156cd21b4a69de969eb6716864f4c8b82a82a" }
 prize = 0.04
 status = "solved"
-public_key = "03a2efa402fd5268400c77c20e574ba86409ededee7c4020e4b9f0edbee53de0d4"
-pubkey_format = "compressed"
+pubkey = { value = "03a2efa402fd5268400c77c20e574ba86409ededee7c4020e4b9f0edbee53de0d4", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -505,8 +465,7 @@ key = { bits = 41, hex = "000000000000000000000000000000000000000000000000000001
 address = { value = "1L5sU9qvJeuwQUdt4y1eiLmquFxKjtHr3E", kind = "p2pkh", hash160 = "d1562eb37357f9e6fc41cb2359f4d3eda4032329" }
 prize = 0.041
 status = "solved"
-public_key = "03b357e68437da273dcf995a474a524439faad86fc9effc300183f714b0903468b"
-pubkey_format = "compressed"
+pubkey = { value = "03b357e68437da273dcf995a474a524439faad86fc9effc300183f714b0903468b", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -517,8 +476,7 @@ key = { bits = 42, hex = "000000000000000000000000000000000000000000000000000002
 address = { value = "1E32GPWgDyeyQac4aJxm9HVoLrrEYPnM4N", kind = "p2pkh", hash160 = "8efb85f9c5b5db2d55973a04128dc7510075ae23" }
 prize = 0.042
 status = "solved"
-public_key = "03eec88385be9da803a0d6579798d977a5d0c7f80917dab49cb73c9e3927142cb6"
-pubkey_format = "compressed"
+pubkey = { value = "03eec88385be9da803a0d6579798d977a5d0c7f80917dab49cb73c9e3927142cb6", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -529,8 +487,7 @@ key = { bits = 43, hex = "000000000000000000000000000000000000000000000000000006
 address = { value = "1PiFuqGpG8yGM5v6rNHWS3TjsG6awgEGA1", kind = "p2pkh", hash160 = "f92044c7924e5525c61207972c253c9fc9f086f7" }
 prize = 0.043
 status = "solved"
-public_key = "02a631f9ba0f28511614904df80d7f97a4f43f02249c8909dac92276ccf0bcdaed"
-pubkey_format = "compressed"
+pubkey = { value = "02a631f9ba0f28511614904df80d7f97a4f43f02249c8909dac92276ccf0bcdaed", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -541,8 +498,7 @@ key = { bits = 44, hex = "00000000000000000000000000000000000000000000000000000e
 address = { value = "1CkR2uS7LmFwc3T2jV8C1BhWb5mQaoxedF", kind = "p2pkh", hash160 = "80df54e1f612f2fc5bdc05c9d21a83aa8d20791e" }
 prize = 0.044
 status = "solved"
-public_key = "025e466e97ed0e7910d3d90ceb0332df48ddf67d456b9e7303b50a3d89de357336"
-pubkey_format = "compressed"
+pubkey = { value = "025e466e97ed0e7910d3d90ceb0332df48ddf67d456b9e7303b50a3d89de357336", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -553,8 +509,7 @@ key = { bits = 45, hex = "000000000000000000000000000000000000000000000000000012
 address = { value = "1NtiLNGegHWE3Mp9g2JPkgx6wUg4TW7bbk", kind = "p2pkh", hash160 = "f0225bfc68a6e17e87cd8b5e60ae3be18f120753" }
 prize = 0.045
 status = "solved"
-public_key = "026ecabd2d22fdb737be21975ce9a694e108eb94f3649c586cc7461c8abf5da71a"
-pubkey_format = "compressed"
+pubkey = { value = "026ecabd2d22fdb737be21975ce9a694e108eb94f3649c586cc7461c8abf5da71a", format = "compressed" }
 solve_date = "2015-01-30 18:24:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1297024
@@ -565,8 +520,7 @@ key = { bits = 46, hex = "00000000000000000000000000000000000000000000000000002e
 address = { value = "1F3JRMWudBaj48EhwcHDdpeuy2jwACNxjP", kind = "p2pkh", hash160 = "9a012260d01c5113df66c8a8438c9f7a1e3d5dac" }
 prize = 0.046
 status = "solved"
-public_key = "03fd5487722d2576cb6d7081426b66a3e2986c1ce8358d479063fb5f2bb6dd5849"
-pubkey_format = "compressed"
+pubkey = { value = "03fd5487722d2576cb6d7081426b66a3e2986c1ce8358d479063fb5f2bb6dd5849", format = "compressed" }
 solve_date = "2015-01-30 21:04:12"
 start_date = "2015-01-15 18:07:14"
 solve_time = 1306618
@@ -577,8 +531,7 @@ key = { bits = 47, hex = "00000000000000000000000000000000000000000000000000006c
 address = { value = "1Pd8VvT49sHKsmqrQiP61RsVwmXCZ6ay7Z", kind = "p2pkh", hash160 = "f828005d41b0f4fed4c8dca3b06011072cfb07d4" }
 prize = 0.047
 status = "solved"
-public_key = "023a12bd3caf0b0f77bf4eea8e7a40dbe27932bf80b19ac72f5f5a64925a594196"
-pubkey_format = "compressed"
+pubkey = { value = "023a12bd3caf0b0f77bf4eea8e7a40dbe27932bf80b19ac72f5f5a64925a594196", format = "compressed" }
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
 solve_time = 19793590
@@ -589,8 +542,7 @@ key = { bits = 48, hex = "0000000000000000000000000000000000000000000000000000ad
 address = { value = "1DFYhaB2J9q1LLZJWKTnscPWos9VBqDHzv", kind = "p2pkh", hash160 = "8661cb56d9df0a61f01328b55af7e56a3fe7a2b2" }
 prize = 0.048
 status = "solved"
-public_key = "0291bee5cf4b14c291c650732faa166040e4c18a14731f9a930c1e87d3ec12debb"
-pubkey_format = "compressed"
+pubkey = { value = "0291bee5cf4b14c291c650732faa166040e4c18a14731f9a930c1e87d3ec12debb", format = "compressed" }
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
 solve_time = 19793590
@@ -601,8 +553,7 @@ key = { bits = 49, hex = "000000000000000000000000000000000000000000000000000174
 address = { value = "12CiUhYVTTH33w3SPUBqcpMoqnApAV4WCF", kind = "p2pkh", hash160 = "0d2f533966c6578e1111978ca698f8add7fffdf3" }
 prize = 0.049
 status = "solved"
-public_key = "02591d682c3da4a2a698633bf5751738b67c343285ebdc3492645cb44658911484"
-pubkey_format = "compressed"
+pubkey = { value = "02591d682c3da4a2a698633bf5751738b67c343285ebdc3492645cb44658911484", format = "compressed" }
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
 solve_time = 19793590
@@ -613,8 +564,7 @@ key = { bits = 50, hex = "00000000000000000000000000000000000000000000000000022b
 address = { value = "1MEzite4ReNuWaL5Ds17ePKt2dCxWEofwk", kind = "p2pkh", hash160 = "de081b76f840e462fa2cdf360173dfaf4a976a47" }
 prize = 0.05
 status = "solved"
-public_key = "03f46f41027bbf44fafd6b059091b900dad41e6845b2241dc3254c7cdd3c5a16c6"
-pubkey_format = "compressed"
+pubkey = { value = "03f46f41027bbf44fafd6b059091b900dad41e6845b2241dc3254c7cdd3c5a16c6", format = "compressed" }
 solve_date = "2015-09-01 20:20:24"
 start_date = "2015-01-15 18:07:14"
 solve_time = 19793590
@@ -625,8 +575,7 @@ key = { bits = 51, hex = "000000000000000000000000000000000000000000000000000750
 address = { value = "1NpnQyZ7x24ud82b7WiRNvPm6N8bqGQnaS", kind = "p2pkh", hash160 = "ef6419cffd7fad7027994354eb8efae223c2dbe7" }
 prize = 0.051
 status = "solved"
-public_key = "028c6c67bef9e9eebe6a513272e50c230f0f91ed560c37bc9b033241ff6c3be78f"
-pubkey_format = "compressed"
+pubkey = { value = "028c6c67bef9e9eebe6a513272e50c230f0f91ed560c37bc9b033241ff6c3be78f", format = "compressed" }
 solve_date = "2017-04-05 10:11:20"
 start_date = "2015-01-15 18:07:14"
 solve_time = 70041846
@@ -637,8 +586,7 @@ key = { bits = 52, hex = "000000000000000000000000000000000000000000000000000efa
 address = { value = "15z9c9sVpu6fwNiK7dMAFgMYSK4GqsGZim", kind = "p2pkh", hash160 = "36af659edbe94453f6344e920d143f1778653ae7" }
 prize = 0.052
 status = "solved"
-public_key = "0374c33bd548ef02667d61341892134fcf216640bc2201ae61928cd0874f6314a7"
-pubkey_format = "compressed"
+pubkey = { value = "0374c33bd548ef02667d61341892134fcf216640bc2201ae61928cd0874f6314a7", format = "compressed" }
 solve_date = "2017-04-21 18:10:05"
 start_date = "2015-01-15 18:07:14"
 solve_time = 71452971
@@ -649,8 +597,7 @@ key = { bits = 53, hex = "000000000000000000000000000000000000000000000000001807
 address = { value = "15K1YKJMiJ4fpesTVUcByoz334rHmknxmT", kind = "p2pkh", hash160 = "2f4870ef54fa4b048c1365d42594cc7d3d269551" }
 prize = 0.53
 status = "solved"
-public_key = "020faaf5f3afe58300a335874c80681cf66933e2a7aeb28387c0d28bb048bc6349"
-pubkey_format = "compressed"
+pubkey = { value = "020faaf5f3afe58300a335874c80681cf66933e2a7aeb28387c0d28bb048bc6349", format = "compressed" }
 solve_date = "2017-09-04 20:23:27"
 start_date = "2015-01-15 18:07:14"
 solve_time = 83211373
@@ -661,8 +608,7 @@ key = { bits = 54, hex = "00000000000000000000000000000000000000000000000000236f
 address = { value = "1KYUv7nSvXx4642TKeuC2SNdTk326uUpFy", kind = "p2pkh", hash160 = "cb66763cf7fde659869ae7f06884d9a0f879a092" }
 prize = 0.54
 status = "solved"
-public_key = "034af4b81f8c450c2c870ce1df184aff1297e5fcd54944d98d81e1a545ffb22596"
-pubkey_format = "compressed"
+pubkey = { value = "034af4b81f8c450c2c870ce1df184aff1297e5fcd54944d98d81e1a545ffb22596", format = "compressed" }
 solve_date = "2017-11-16 11:04:22"
 start_date = "2015-01-15 18:07:14"
 solve_time = 89485028
@@ -673,8 +619,7 @@ key = { bits = 55, hex = "000000000000000000000000000000000000000000000000006abe
 address = { value = "1LzhS3k3e9Ub8i2W1V8xQFdB8n2MYCHPCa", kind = "p2pkh", hash160 = "db53d9bbd1f3a83b094eeca7dd970bd85b492fa2" }
 prize = 0.55
 status = "solved"
-public_key = "0385a30d8413af4f8f9e6312400f2d194fe14f02e719b24c3f83bf1fd233a8f963"
-pubkey_format = "compressed"
+pubkey = { value = "0385a30d8413af4f8f9e6312400f2d194fe14f02e719b24c3f83bf1fd233a8f963", format = "compressed" }
 solve_date = "2018-05-29 08:13:52"
 start_date = "2015-01-15 18:07:14"
 solve_time = 106236398
@@ -685,8 +630,7 @@ key = { bits = 56, hex = "000000000000000000000000000000000000000000000000009d18
 address = { value = "17aPYR1m6pVAacXg1PTDDU7XafvK1dxvhi", kind = "p2pkh", hash160 = "48214c5969ae9f43f75070cea1e2cb41d5bdcccd" }
 prize = 0.56
 status = "solved"
-public_key = "033f2db2074e3217b3e5ee305301eeebb1160c4fa1e993ee280112f6348637999a"
-pubkey_format = "compressed"
+pubkey = { value = "033f2db2074e3217b3e5ee305301eeebb1160c4fa1e993ee280112f6348637999a", format = "compressed" }
 solve_date = "2018-09-08 05:45:09"
 start_date = "2015-01-15 18:07:14"
 solve_time = 115040275
@@ -697,8 +641,7 @@ key = { bits = 57, hex = "00000000000000000000000000000000000000000000000001eb25
 address = { value = "15c9mPGLku1HuW9LRtBf4jcHVpBUt8txKz", kind = "p2pkh", hash160 = "328660ef43f66abe2653fa178452a5dfc594c2a1" }
 prize = 0.57
 status = "solved"
-public_key = "02a521a07e98f78b03fc1e039bc3a51408cd73119b5eb116e583fe57dc8db07aea"
-pubkey_format = "compressed"
+pubkey = { value = "02a521a07e98f78b03fc1e039bc3a51408cd73119b5eb116e583fe57dc8db07aea", format = "compressed" }
 solve_date = "2018-11-08 01:03:19"
 start_date = "2015-01-15 18:07:14"
 solve_time = 120293765
@@ -709,8 +652,7 @@ key = { bits = 58, hex = "00000000000000000000000000000000000000000000000002c675
 address = { value = "1Dn8NF8qDyyfHMktmuoQLGyjWmZXgvosXf", kind = "p2pkh", hash160 = "8c2a6071f89c90c4dab5ab295d7729d1b54ea60f" }
 prize = 0.58
 status = "solved"
-public_key = "0311569442e870326ceec0de24eb5478c19e146ecd9d15e4666440f2f638875f42"
-pubkey_format = "compressed"
+pubkey = { value = "0311569442e870326ceec0de24eb5478c19e146ecd9d15e4666440f2f638875f42", format = "compressed" }
 solve_date = "2018-12-03 06:03:22"
 start_date = "2015-01-15 18:07:14"
 solve_time = 122471768
@@ -721,8 +663,7 @@ key = { bits = 59, hex = "00000000000000000000000000000000000000000000000007496c
 address = { value = "1HAX2n9Uruu9YDt4cqRgYcvtGvZj1rbUyt", kind = "p2pkh", hash160 = "b14ed3146f5b2c9bde1703deae9ef33af8110210" }
 prize = 0.59
 status = "solved"
-public_key = "0241267d2d7ee1a8e76f8d1546d0d30aefb2892d231cee0dde7776daf9f8021485"
-pubkey_format = "compressed"
+pubkey = { value = "0241267d2d7ee1a8e76f8d1546d0d30aefb2892d231cee0dde7776daf9f8021485", format = "compressed" }
 solve_date = "2019-02-11 22:39:32"
 start_date = "2015-01-15 18:07:14"
 solve_time = 128579538
@@ -733,8 +674,7 @@ key = { bits = 60, hex = "0000000000000000000000000000000000000000000000000fc07a
 address = { value = "1Kn5h2qpgw9mWE5jKpk8PP4qvvJ1QVy8su", kind = "p2pkh", hash160 = "cdf8e5c7503a9d22642e3ecfc87817672787b9c5" }
 prize = 0.6
 status = "solved"
-public_key = "0348e843dc5b1bd246e6309b4924b81543d02b16c8083df973a89ce2c7eb89a10d"
-pubkey_format = "compressed"
+pubkey = { value = "0348e843dc5b1bd246e6309b4924b81543d02b16c8083df973a89ce2c7eb89a10d", format = "compressed" }
 solve_date = "2019-02-17 11:59:52"
 start_date = "2015-01-15 18:07:14"
 solve_time = 129059558
@@ -745,8 +685,7 @@ key = { bits = 61, hex = "00000000000000000000000000000000000000000000000013c96a
 address = { value = "1AVJKwzs9AskraJLGHAZPiaZcrpDr1U6AB", kind = "p2pkh", hash160 = "68133e19b2dfb9034edf9830a200cfdf38c90cbd" }
 prize = 0.61
 status = "solved"
-public_key = "0249a43860d115143c35c09454863d6f82a95e47c1162fb9b2ebe0186eb26f453f"
-pubkey_format = "compressed"
+pubkey = { value = "0249a43860d115143c35c09454863d6f82a95e47c1162fb9b2ebe0186eb26f453f", format = "compressed" }
 solve_date = "2019-05-11 12:53:18"
 start_date = "2015-01-15 18:07:14"
 solve_time = 136233964
@@ -757,8 +696,7 @@ key = { bits = 62, hex = "000000000000000000000000000000000000000000000000363d54
 address = { value = "1Me6EfpwZK5kQziBwBfvLiHjaPGxCKLoJi", kind = "p2pkh", hash160 = "e26646db84b0602f32b34b5a62ca3cae1f91b779" }
 prize = 0.62
 status = "solved"
-public_key = "03231a67e424caf7d01a00d5cd49b0464942255b8e48766f96602bdfa4ea14fea8"
-pubkey_format = "compressed"
+pubkey = { value = "03231a67e424caf7d01a00d5cd49b0464942255b8e48766f96602bdfa4ea14fea8", format = "compressed" }
 solve_date = "2019-09-08 10:51:01"
 start_date = "2015-01-15 18:07:14"
 solve_time = 146594627
@@ -769,8 +707,7 @@ key = { bits = 63, hex = "0000000000000000000000000000000000000000000000007cce5e
 address = { value = "1NpYjtLira16LfGbGwZJ5JbDPh3ai9bjf4", kind = "p2pkh", hash160 = "ef58afb697b094423ce90721fbb19a359ef7c50e" }
 prize = 0.63
 status = "solved"
-public_key = "0365ec2994b8cc0a20d40dd69edfe55ca32a54bcbbaa6b0ddcff36049301a54579"
-pubkey_format = "compressed"
+pubkey = { value = "0365ec2994b8cc0a20d40dd69edfe55ca32a54bcbbaa6b0ddcff36049301a54579", format = "compressed" }
 solve_date = "2019-07-12 12:26:39"
 start_date = "2015-01-15 18:07:14"
 solve_time = 141589165
@@ -781,8 +718,7 @@ key = { bits = 64, hex = "000000000000000000000000000000000000000000000000f7051f
 address = { value = "16jY7qLJnxb7CHZyqBP8qca9d51gAjyXQN", kind = "p2pkh", hash160 = "3ee4133d991f52fdf6a25c9834e0745ac74248a4" }
 prize = 0.64
 status = "solved"
-public_key = "03100611c54dfef604163b8358f7b7fac13ce478e02cb224ae16d45526b25d9d4d"
-pubkey_format = "compressed"
+pubkey = { value = "03100611c54dfef604163b8358f7b7fac13ce478e02cb224ae16d45526b25d9d4d", format = "compressed" }
 solve_date = "2022-09-09 22:49:03"
 start_date = "2015-01-15 18:07:14"
 solve_time = 241418509
@@ -793,8 +729,7 @@ key = { bits = 65, hex = "000000000000000000000000000000000000000000000001a838b1
 address = { value = "18ZMbwUFLMHoZBbfpCjUJQTCMCbktshgpe", kind = "p2pkh", hash160 = "52e763a7ddc1aa4fa811578c491c1bc7fd570137" }
 prize = 0.65
 status = "solved"
-public_key = "0230210c23b1a047bc9bdbb13448e67deddc108946de6de639bcc75d47c0216b1b"
-pubkey_format = "compressed"
+pubkey = { value = "0230210c23b1a047bc9bdbb13448e67deddc108946de6de639bcc75d47c0216b1b", format = "compressed" }
 solve_date = "2019-06-07 16:39:02"
 start_date = "2015-01-15 18:07:14"
 solve_time = 138580308
@@ -805,8 +740,7 @@ key = { bits = 66, hex = "000000000000000000000000000000000000000000000002832ed7
 address = { value = "13zb1hQbWVsc2S7ZTZnP2G4undNNpdh5so", kind = "p2pkh", hash160 = "20d45a6a762535700ce9e0b216e31994335db8a5" }
 prize = 6.6
 status = "solved"
-public_key = "024ee2be2d4e9f92d2f5a4a03058617dc45befe22938feed5b7a6b7282dd74cbdd"
-pubkey_format = "compressed"
+pubkey = { value = "024ee2be2d4e9f92d2f5a4a03058617dc45befe22938feed5b7a6b7282dd74cbdd", format = "compressed" }
 solve_date = "2024-09-12 22:59:39"
 start_date = "2015-01-15 18:07:14"
 solve_time = 304836745
@@ -818,8 +752,7 @@ key = { bits = 67, hex = "00000000000000000000000000000000000000000000000730fc23
 address = { value = "1BY8GQbnueYofwSuFAT3USAhGjPrkxDdW9", kind = "p2pkh", hash160 = "739437bb3dd6d1983e66629c5f08c70e52769371" }
 prize = 6.7
 status = "solved"
-public_key = "0212209f5ec514a1580a2937bd833979d933199fc230e204c6cdc58872b7d46f75"
-pubkey_format = "compressed"
+pubkey = { value = "0212209f5ec514a1580a2937bd833979d933199fc230e204c6cdc58872b7d46f75", format = "compressed" }
 solve_date = "2025-02-21 01:41:01"
 start_date = "2015-01-15 18:07:14"
 solve_time = 318756827
@@ -831,8 +764,7 @@ key = { bits = 68, hex = "00000000000000000000000000000000000000000000000bebb394
 address = { value = "1MVDYgVaSN6iKKEsbzRUAYFrYJadLYZvvZ", kind = "p2pkh", hash160 = "e0b8a2baee1b77fc703455f39d51477451fc8cfc" }
 prize = 6.8
 status = "solved"
-public_key = "031fe02f1d740637a7127cdfe8a77a8a0cfc6435f85e7ec3282cb6243c0a93ba1b"
-pubkey_format = "compressed"
+pubkey = { value = "031fe02f1d740637a7127cdfe8a77a8a0cfc6435f85e7ec3282cb6243c0a93ba1b", format = "compressed" }
 solve_date = "2025-04-06 22:52:42"
 start_date = "2015-01-15 18:07:14"
 solve_time = 322634728
@@ -844,8 +776,7 @@ key = { bits = 69, hex = "0000000000000000000000000000000000000000000000101d8327
 address = { value = "19vkiEajfhuZ8bs8Zu2jgmC6oqZbWqhxhG", kind = "p2pkh", hash160 = "61eb8a50c86b0584bb727dd65bed8d2400d6d5aa" }
 prize = 6.9
 status = "solved"
-public_key = "024babadccc6cfd5f0e5e7fd2a50aa7d677ce0aa16fdce26a0d0882eed03e7ba53"
-pubkey_format = "compressed"
+pubkey = { value = "024babadccc6cfd5f0e5e7fd2a50aa7d677ce0aa16fdce26a0d0882eed03e7ba53", format = "compressed" }
 solve_date = "2025-04-30 14:45:54"
 start_date = "2015-01-15 18:07:14"
 solve_time = 324679120
@@ -857,8 +788,7 @@ key = { bits = 70, hex = "0000000000000000000000000000000000000000000000349b84b6
 address = { value = "19YZECXj3SxEZMoUeJ1yiPsw8xANe7M7QR", kind = "p2pkh", hash160 = "5db8cda53a6a002db10365967d7f85d19e171b10" }
 prize = 0.7
 status = "solved"
-public_key = "0290e6900a58d33393bc1097b5aed31f2e4e7cbd3e5466af958665bc0121248483"
-pubkey_format = "compressed"
+pubkey = { value = "0290e6900a58d33393bc1097b5aed31f2e4e7cbd3e5466af958665bc0121248483", format = "compressed" }
 solve_date = "2019-06-09 17:08:45"
 start_date = "2015-01-15 18:07:14"
 solve_time = 138754891
@@ -902,8 +832,7 @@ key = { bits = 75, hex = "0000000000000000000000000000000000000000000004c5ce1146
 address = { value = "1J36UjUByGroXcCvmj13U6uwaVv9caEeAt", kind = "p2pkh", hash160 = "badf8b0d34289e679ec65c6c61d3a974353be5cf" }
 prize = 0.75
 status = "solved"
-public_key = "03726b574f193e374686d8e12bc6e4142adeb06770e0a2856f5e4ad89f66044755"
-pubkey_format = "compressed"
+pubkey = { value = "03726b574f193e374686d8e12bc6e4142adeb06770e0a2856f5e4ad89f66044755", format = "compressed" }
 solve_date = "2019-06-10 21:05:57"
 start_date = "2015-01-15 18:07:14"
 solve_time = 138855523
@@ -946,8 +875,7 @@ key = { bits = 80, hex = "00000000000000000000000000000000000000000000ea1a5c66dc
 address = { value = "1BCf6rHUW6m3iH2ptsvnjgLruAiPQQepLe", kind = "p2pkh", hash160 = "6fe5a36eef0684af0b91f3b6cfc972d68c4f6fab" }
 prize = 0.8
 status = "solved"
-public_key = "037e1238f7b1ce757df94faa9a2eb261bf0aeb9f84dbf81212104e78931c2a19dc"
-pubkey_format = "compressed"
+pubkey = { value = "037e1238f7b1ce757df94faa9a2eb261bf0aeb9f84dbf81212104e78931c2a19dc", format = "compressed" }
 solve_date = "2019-06-11 11:08:53"
 start_date = "2015-01-15 18:07:14"
 solve_time = 138906099
@@ -990,8 +918,7 @@ key = { bits = 85, hex = "00000000000000000000000000000000000000000011720c4f018d
 address = { value = "1Kh22PvXERd2xpTQk3ur6pPEqFeckCJfAr", kind = "p2pkh", hash160 = "cd03c1e6268ce9b89e3c3eeab8d0f1b6e8cac281" }
 prize = 0.85
 status = "solved"
-public_key = "0329c4574a4fd8c810b7e42a4b398882b381bcd85e40c6883712912d167c83e73a"
-pubkey_format = "compressed"
+pubkey = { value = "0329c4574a4fd8c810b7e42a4b398882b381bcd85e40c6883712912d167c83e73a", format = "compressed" }
 solve_date = "2019-06-17 00:09:39"
 start_date = "2015-01-15 18:07:14"
 solve_time = 139384945
@@ -1034,8 +961,7 @@ key = { bits = 90, hex = "000000000000000000000000000000000000000002ce00bb2136a4
 address = { value = "1L12FHH2FHjvTviyanuiFVfmzCy46RRATU", kind = "p2pkh", hash160 = "d06b6e206691295ec345782d7ea0686969d8674b" }
 prize = 0.9
 status = "solved"
-public_key = "035c38bd9ae4b10e8a250857006f3cfd98ab15a6196d9f4dfd25bc7ecc77d788d5"
-pubkey_format = "compressed"
+pubkey = { value = "035c38bd9ae4b10e8a250857006f3cfd98ab15a6196d9f4dfd25bc7ecc77d788d5", format = "compressed" }
 solve_date = "2019-07-01 18:09:22"
 start_date = "2015-01-15 18:07:14"
 solve_time = 140659328
@@ -1078,8 +1004,7 @@ key = { bits = 95, hex = "0000000000000000000000000000000000000000527a792b183c7f
 address = { value = "19eVSDuizydXxhohGh8Ki9WY9KsHdSwoQC", kind = "p2pkh", hash160 = "5ed822125365274262191d2b77e88d436dd56d88" }
 prize = 0.95
 status = "solved"
-public_key = "02967a5905d6f3b420959a02789f96ab4c3223a2c4d2762f817b7895c5bc88a045"
-pubkey_format = "compressed"
+pubkey = { value = "02967a5905d6f3b420959a02789f96ab4c3223a2c4d2762f817b7895c5bc88a045", format = "compressed" }
 solve_date = "2019-07-06 06:53:41"
 start_date = "2015-01-15 18:07:14"
 solve_time = 141050787
@@ -1122,8 +1047,7 @@ key = { bits = 100, hex = "000000000000000000000000000000000000000af55fc59c335c8
 address = { value = "1KCgMv8fo2TPBpddVi9jqmMmcne9uSNJ5F", kind = "p2pkh", hash160 = "c7a7b23f6bd98b8aaf527beb724dda9460b1bc6e" }
 prize = 1.0
 status = "solved"
-public_key = "03d2063d40402f030d4cc71331468827aa41a8a09bd6fd801ba77fb64f8e67e617"
-pubkey_format = "compressed"
+pubkey = { value = "03d2063d40402f030d4cc71331468827aa41a8a09bd6fd801ba77fb64f8e67e617", format = "compressed" }
 solve_date = "2019-07-08 04:57:04"
 start_date = "2015-01-15 18:07:14"
 solve_time = 141216590
@@ -1166,8 +1090,7 @@ key = { bits = 105, hex = "000000000000000000000000000000000000016f14fc2054cd87e
 address = { value = "1CMjscKB3QW7SDyQ4c3C3DEUHiHRhiZVib", kind = "p2pkh", hash160 = "7c957db6fdd0733bb83bc6d6d747711263ba50b0" }
 prize = 1.05
 status = "solved"
-public_key = "03bcf7ce887ffca5e62c9cabbdb7ffa71dc183c52c04ff4ee5ee82e0c55c39d77b"
-pubkey_format = "compressed"
+pubkey = { value = "03bcf7ce887ffca5e62c9cabbdb7ffa71dc183c52c04ff4ee5ee82e0c55c39d77b", format = "compressed" }
 solve_date = "2019-09-23 01:29:47"
 start_date = "2015-01-15 18:07:14"
 solve_time = 147856953
@@ -1210,8 +1133,7 @@ key = { bits = 110, hex = "00000000000000000000000000000000000035c0d7234df7deb0f
 address = { value = "12JzYkkN76xkwvcPT6AWKZtGX6w2LAgsJg", kind = "p2pkh", hash160 = "0e5f3c406397442996825fd395543514fd06f207" }
 prize = 1.1
 status = "solved"
-public_key = "0309976ba5570966bf889196b7fdf5a0f9a1e9ab340556ec29f8bb60599616167d"
-pubkey_format = "compressed"
+pubkey = { value = "0309976ba5570966bf889196b7fdf5a0f9a1e9ab340556ec29f8bb60599616167d", format = "compressed" }
 solve_date = "2020-05-30 20:04:06"
 start_date = "2015-01-15 18:07:14"
 solve_time = 169523812
@@ -1254,8 +1176,7 @@ key = { bits = 115, hex = "0000000000000000000000000000000000060f4d11574f5deee49
 address = { value = "1NLbHuJebVwUZ1XqDjsAyfTRUPwDQbemfv", kind = "p2pkh", hash160 = "ea0f2b7576bd098921fce9bfebe37f6383e639a4" }
 prize = 1.15
 status = "solved"
-public_key = "0248d313b0398d4923cdca73b8cfa6532b91b96703902fc8b32fd438a3b7cd7f55"
-pubkey_format = "compressed"
+pubkey = { value = "0248d313b0398d4923cdca73b8cfa6532b91b96703902fc8b32fd438a3b7cd7f55", format = "compressed" }
 solve_date = "2020-06-16 07:33:42"
 start_date = "2015-01-15 18:07:14"
 solve_time = 170947588
@@ -1298,8 +1219,7 @@ key = { bits = 120, hex = "0000000000000000000000000000000000b10f22572c497a836ea
 address = { value = "17s2b9ksz5y7abUm92cHwG8jEPCzK3dLnT", kind = "p2pkh", hash160 = "4b46e10a541aeec6be3fac709c256fb7da69308e" }
 prize = 1.2
 status = "solved"
-public_key = "02ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a2630"
-pubkey_format = "compressed"
+pubkey = { value = "02ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a2630", format = "compressed" }
 solve_date = "2023-02-27 09:40:55"
 start_date = "2015-01-15 18:07:14"
 solve_time = 256145621
@@ -1343,8 +1263,7 @@ key = { bits = 125, hex = "000000000000000000000000000000001c533b6bb7f0804e09960
 address = { value = "1PXAyUB8ZoH3WD8n5zoAthYjN15yN5CVq5", kind = "p2pkh", hash160 = "f7079256aa027dc437cbb539f955472416725fc8" }
 prize = 12.5
 status = "solved"
-public_key = "0233709eb11e0d4439a729f21c2c443dedb727528229713f0065721ba8fa46f00e"
-pubkey_format = "compressed"
+pubkey = { value = "0233709eb11e0d4439a729f21c2c443dedb727528229713f0065721ba8fa46f00e", format = "compressed" }
 solve_date = "2023-07-09 10:24:07"
 start_date = "2015-01-15 18:07:14"
 solve_time = 267553013
@@ -1388,8 +1307,7 @@ key = { bits = 130, hex = "000000000000000000000000000000033e7665705359f04f28b88
 address = { value = "1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua", kind = "p2pkh", hash160 = "a24922852051a9002ebf4c864a55acb75bb4cf75" }
 prize = 13.0
 status = "solved"
-public_key = "03633cbe3ec02b9401c5effa144c5b4d22f87940259634858fc7e59b1c09937852"
-pubkey_format = "compressed"
+pubkey = { value = "03633cbe3ec02b9401c5effa144c5b4d22f87940259634858fc7e59b1c09937852", format = "compressed" }
 solve_date = "2024-09-23 08:13:37"
 start_date = "2015-01-15 18:07:14"
 solve_time = 305733983
@@ -1433,8 +1351,7 @@ key = { bits = 135 }
 address = { value = "16RGFo6hjq9ym6Pj7N5H7L1NR1rVPJyw2v", kind = "p2pkh", hash160 = "3b6f58a75a54bfd85d1bc6c51180fdc732992326" }
 prize = 13.50003408
 status = "unsolved"
-public_key = "02145d2611c823a396ef6712ce0f712f09b9b4f3135e3e0aa3230fb9b6d08d1e16"
-pubkey_format = "compressed"
+pubkey = { value = "02145d2611c823a396ef6712ce0f712f09b9b4f3135e3e0aa3230fb9b6d08d1e16", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.135 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.215 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.15 }, { type = "increase", txid = "e876a49f4f04d687b0b227bf554fbf1878289288291d17339413dd287af27c64", date = "2024-10-09 14:58:21", amount = 0.00002208 }, { type = "increase", txid = "32ea2049816f4bc776a2152bff801a32582d75287d0d79b6b4388b5ba7527fb8", date = "2025-01-28 02:11:50", amount = 0.000006 }, { type = "increase", txid = "3f2ec8791ec73c2216bf1dba98d79624c30bc9bf86abc314404eeec87d43f0c0", date = "2025-03-30 01:49:24", amount = 0.000006 }]
 
@@ -1475,8 +1392,7 @@ key = { bits = 140 }
 address = { value = "1QKBaU6WAeycb3DbKbLBkX7vJiaS8r42Xo", kind = "p2pkh", hash160 = "ffbb35a7bb9bbe16c1aa2534f7ff11d59c8e3d1a" }
 prize = 14.000016
 status = "unsolved"
-public_key = "031f6a332d3c5c4f2de2378c012f429cd109ba07d69690c6c701b6bb87860d6640"
-pubkey_format = "compressed"
+pubkey = { value = "031f6a332d3c5c4f2de2378c012f429cd109ba07d69690c6c701b6bb87860d6640", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.14 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.26 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "d8c38d06fe7ea6adf44c5cc2cbf50083ec9cd8a3fc6c537e8d39db30639e8a77", date = "2022-11-19 17:06:31", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 12.6 }, { type = "increase", txid = "dd23b1079095ec6821f003b5a1acd5942152f478411157d717c8bddf8f67fb94", date = "2025-01-28 07:26:00", amount = 0.000006 }]
 
@@ -1517,8 +1433,7 @@ key = { bits = 145 }
 address = { value = "19GpszRNUej5yYqxXoLnbZWKew3KdVLkXg", kind = "p2pkh", hash160 = "5abf369388deb8072741b4eb43ef10fa9388a729" }
 prize = 14.500006
 status = "unsolved"
-public_key = "03afdda497369e219a2c1c369954a930e4d3740968e5e4352475bcffce3140dae5"
-pubkey_format = "compressed"
+pubkey = { value = "03afdda497369e219a2c1c369954a930e4d3740968e5e4352475bcffce3140dae5", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.145 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.305 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.05 }, { type = "increase", txid = "35c62ac2e2118aea9167f918670ea9e60e4c82029da01b33f82756372faa53e7", date = "2025-01-28 03:11:55", amount = 0.000006 }]
 
@@ -1559,8 +1474,7 @@ key = { bits = 150 }
 address = { value = "1MUJSJYtGPVGkBCTqGspnxyHahpt5Te8jy", kind = "p2pkh", hash160 = "e08c4d3bc9cf2b3e2cb88de2bfaa4fe8c7aa3f24" }
 prize = 15.000016
 status = "unsolved"
-public_key = "03137807790ea7dc6e97901c2bc87411f45ed74a5629315c4e4b03a0a102250c49"
-pubkey_format = "compressed"
+pubkey = { value = "03137807790ea7dc6e97901c2bc87411f45ed74a5629315c4e4b03a0a102250c49", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.15 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.35 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.5 }, { type = "increase", txid = "284ef13f3a81cb301fa1bf570f2cdfeb27d8d93140b9a14950a1a5769ac60071", date = "2025-01-27 14:15:16", amount = 0.000006 }]
 
@@ -1601,8 +1515,7 @@ key = { bits = 155 }
 address = { value = "1AoeP37TmHdFh8uN72fu9AqgtLrUwcv2wJ", kind = "p2pkh", hash160 = "6b8b7830f73c5bf9e8beb9f161ad82b3bde992e4" }
 prize = 15.500116
 status = "unsolved"
-public_key = "035cd1854cae45391ca4ec428cc7e6c7d9984424b954209a8eea197b9e364c05f6"
-pubkey_format = "compressed"
+pubkey = { value = "035cd1854cae45391ca4ec428cc7e6c7d9984424b954209a8eea197b9e364c05f6", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.155 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.395 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "e1f668b8cc9915fcd3de6ec922acf98cdf4c14f75de9530b6ad750693d44076b", date = "2021-08-19 15:55:55", amount = 0.00001 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 13.95 }, { type = "increase", txid = "ddf0c3de51e34363c756e5850f4a2fc1b9af8dcb76a2d7f9e61cebc5526e95de", date = "2025-01-28 07:26:42", amount = 0.000006 }, { type = "increase", txid = "21f8ff5f3bd280004239e4b0c4a4e82f2e8919cf91245800656cf2bb7ec25aa0", date = "2025-05-02 13:12:32", amount = 0.0001 }]
 
@@ -1643,8 +1556,7 @@ key = { bits = 160 }
 address = { value = "1NBC8uXJy1GiJ6drkiZa1WuKn51ps7EPTv", kind = "p2pkh", hash160 = "e84818e1bf7f699aa6e28ef9edfb582099099292" }
 prize = 16.00119082
 status = "unsolved"
-public_key = "02e0a8b039282faf6fe0fd769cfbc4b6b4cf8758ba68220eac420e32b91ddfa673"
-pubkey_format = "compressed"
+pubkey = { value = "02e0a8b039282faf6fe0fd769cfbc4b6b4cf8758ba68220eac420e32b91ddfa673", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.16 }, { type = "increase", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 1.44 }, { type = "increase", txid = "336043f3a5f08e4f08dc25bf7ae61aa74d008641a55e4a8e37d2a71a2d0fbd65", date = "2019-02-24 21:48:34", amount = 0.00000793 }, { type = "increase", txid = "7c432398c7631600af01695c9767eff109cbfae4f7ecccaff388043a474d4f1e", date = "2019-05-16 04:25:45", amount = 0.00001 }, { type = "pubkey_reveal", txid = "17e4e323cfbc68d7f0071cad09364e8193eedf8fefbcbd8a21b4b65717a4b3d3", date = "2019-06-01 02:07:26", amount = 0.00001 }, { type = "increase", txid = "6b2f1287b8e6f9b4394977a2d389313647ef0f004d6ef0f752a03d014a10a021", date = "2022-11-14 13:12:25", amount = 0.000015 }, { type = "increase", txid = "12f34b58b04dfb0233ce889f674781c0e0c7ba95482cca469125af41a78d13b3", date = "2023-04-16 06:29:48", amount = 14.4 }, { type = "increase", txid = "f28d7dda479bc61ac34fc762226634e51135b6a6609b2a774e1e4495f9f996ed", date = "2023-09-25 15:00:17", amount = 0.00003768 }, { type = "increase", txid = "d864c1a02f3ba7028d4a0723bc64102b04d3afea7e2a114e2d6db515489750ff", date = "2023-10-23 08:45:40", amount = 0.000006 }, { type = "increase", txid = "4cab5e1213071d60d6e452a6b4e9caefbbae44611c3dc2bd757a639a1f85fdd2", date = "2024-06-29 08:18:58", amount = 0.00000821 }, { type = "increase", txid = "9ad34108526a0491386df4055dae20456551288aba2a8893fccdd6842ab29f7e", date = "2024-07-13 16:22:21", amount = 0.0001 }, { type = "increase", txid = "e2e8e1988044d6195dc6f076a9d5810eec4f3493667b536ddec898dcacc10d4f", date = "2024-07-13 19:07:25", amount = 0.00001 }, { type = "increase", txid = "65ef98ecd6392c4add3fd280f322baa252b697a1b1ab240db0876f004a88a405", date = "2025-01-09 18:32:51", amount = 0.000006 }, { type = "increase", txid = "ae3c5d4277175a604a125f7b4461a083ca1a4dcfd5110b4c77ee773dea7a6877", date = "2025-05-02 09:59:40", amount = 0.001 }]
 
@@ -1653,8 +1565,7 @@ key = { bits = 161 }
 address = { value = "1JkqBQcC4tHcb1JfdCH6nrWYwTPGznHANh", kind = "p2pkh", hash160 = "c2c43e2b16f53c713bc00307140eaae188413544" }
 prize = 0.161
 status = "swept"
-public_key = "031dcf49b480cee5f1a7200ea94795a1c7f69e144f11f031123c14c65077823dcb"
-pubkey_format = "compressed"
+pubkey = { value = "031dcf49b480cee5f1a7200ea94795a1c7f69e144f11f031123c14c65077823dcb", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.161 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.161 }]
 
@@ -1663,8 +1574,7 @@ key = { bits = 162 }
 address = { value = "17DTUTXUcUYEgrr5GhivxYei4Lrs1xMnS2", kind = "p2pkh", hash160 = "442bd85a46d4acd7b082c1d731fb13c8474ffa6f" }
 prize = 0.162
 status = "swept"
-public_key = "03294d33f5e7b98c885ff540fd3f747010999f640d8fdb021f5a13ef3d06c36a58"
-pubkey_format = "compressed"
+pubkey = { value = "03294d33f5e7b98c885ff540fd3f747010999f640d8fdb021f5a13ef3d06c36a58", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.162 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.162 }]
 
@@ -1673,8 +1583,7 @@ key = { bits = 163 }
 address = { value = "1H6e7SLxv6ZUbuAaZpeUdVNfh3cKBWJRmx", kind = "p2pkh", hash160 = "b093122f7fb36d11c9f2c80cff2971fba7c9c1ff" }
 prize = 0.163
 status = "swept"
-public_key = "02ee740ba74efc08bf39d01ccb7e34f50afe2f4677a9e09755e7fe3808e0cbbac9"
-pubkey_format = "compressed"
+pubkey = { value = "02ee740ba74efc08bf39d01ccb7e34f50afe2f4677a9e09755e7fe3808e0cbbac9", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.163 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.163 }]
 
@@ -1683,8 +1592,7 @@ key = { bits = 164 }
 address = { value = "1LjQKurNtEDgMdqeCoWRFhHp1FPnLU77Q4", kind = "p2pkh", hash160 = "d86f54f73e343d76dd7401639e427d828ba31eab" }
 prize = 0.164
 status = "swept"
-public_key = "0312163c60548244d6e565bd877b98808b73830c537efde357c8b5f8c623fb2028"
-pubkey_format = "compressed"
+pubkey = { value = "0312163c60548244d6e565bd877b98808b73830c537efde357c8b5f8c623fb2028", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.164 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.164 }]
 
@@ -1693,8 +1601,7 @@ key = { bits = 165 }
 address = { value = "1F7ZjibYug9bLW3YvkkwBZLrhfLtNjgYrX", kind = "p2pkh", hash160 = "9acf9573eb7b4376beca979cfa769f0677cfd949" }
 prize = 0.165
 status = "swept"
-public_key = "037c6fcde6a2e0fd57ce21bb4352f7bb38859d2af5388b27ebfed107907e060c5c"
-pubkey_format = "compressed"
+pubkey = { value = "037c6fcde6a2e0fd57ce21bb4352f7bb38859d2af5388b27ebfed107907e060c5c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.165 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.165 }]
 
@@ -1703,8 +1610,7 @@ key = { bits = 166 }
 address = { value = "12BtvPaamiBCpXmoDrsCxAa1b6hMRnASZ4", kind = "p2pkh", hash160 = "0d07a05f7687824fb4dd4a160ddbdc3808655004" }
 prize = 0.166
 status = "swept"
-public_key = "02b02f753542201387815c4754b66202ef6dc4b3415e4c4cc826d6534394702f50"
-pubkey_format = "compressed"
+pubkey = { value = "02b02f753542201387815c4754b66202ef6dc4b3415e4c4cc826d6534394702f50", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.166 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.166 }]
 
@@ -1713,8 +1619,7 @@ key = { bits = 167 }
 address = { value = "1AvLwGpkwTZH4qiwy1L4v6TuWXLMNrATN5", kind = "p2pkh", hash160 = "6ccfd1cdb43788738536e11e247b0ce31c093f0f" }
 prize = 0.167
 status = "swept"
-public_key = "03779c01b4badc5c3883f6ea2b93214a24796154c8eb967695dfc802bf074b4941"
-pubkey_format = "compressed"
+pubkey = { value = "03779c01b4badc5c3883f6ea2b93214a24796154c8eb967695dfc802bf074b4941", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.167 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.167 }]
 
@@ -1723,8 +1628,7 @@ key = { bits = 168 }
 address = { value = "1PojqbbzJHnn1X2mv6DCECNLUaD2nMssDp", kind = "p2pkh", hash160 = "fa29a9264b9c18fa5925e38d201934ed89e64dd6" }
 prize = 0.168
 status = "swept"
-public_key = "02788f82521d7557d30c9c4f8bc7098cda23c59729e9cf96057ea1dc49799bd399"
-pubkey_format = "compressed"
+pubkey = { value = "02788f82521d7557d30c9c4f8bc7098cda23c59729e9cf96057ea1dc49799bd399", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.168 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.168 }]
 
@@ -1733,8 +1637,7 @@ key = { bits = 169 }
 address = { value = "1G3uazv67BcKRmPFvgvX4ijBTa2898cvCm", kind = "p2pkh", hash160 = "a5169d8bc79e8cc94a36246de6bde7596cc9f4bb" }
 prize = 0.169
 status = "swept"
-public_key = "026efbd90dfd84d5bfb7a8ceb2755155d1d39a16be88db336ff18a8d844a269cba"
-pubkey_format = "compressed"
+pubkey = { value = "026efbd90dfd84d5bfb7a8ceb2755155d1d39a16be88db336ff18a8d844a269cba", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.169 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.169 }]
 
@@ -1743,8 +1646,7 @@ key = { bits = 170 }
 address = { value = "1EW9W5sGdxVDxAtjRbCjgkZNtPH8ZzikeP", kind = "p2pkh", hash160 = "941ccb7383109b47b841044c9f865785676b0918" }
 prize = 0.17
 status = "swept"
-public_key = "03e56c48f1bc4a6d06a2e0a4ad53c7674403dbfdaaeee3ecc86aff294b04997d61"
-pubkey_format = "compressed"
+pubkey = { value = "03e56c48f1bc4a6d06a2e0a4ad53c7674403dbfdaaeee3ecc86aff294b04997d61", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.17 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.17 }]
 
@@ -1753,8 +1655,7 @@ key = { bits = 171 }
 address = { value = "17zzMMnj5h8StLhnrXpw8iBP21uujNC4Ap", kind = "p2pkh", hash160 = "4cc856b74f1be643a3a0ac65f5399e018aed7ae5" }
 prize = 0.171
 status = "swept"
-public_key = "021b6f7d2e3d33f99fa44985c68ae85827282c64701a2c663bd81e18a229a3562d"
-pubkey_format = "compressed"
+pubkey = { value = "021b6f7d2e3d33f99fa44985c68ae85827282c64701a2c663bd81e18a229a3562d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.171 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.171 }]
 
@@ -1763,8 +1664,7 @@ key = { bits = 172 }
 address = { value = "15LJKhwQJ7dYMBZX1mktskZqxX1aUCibkr", kind = "p2pkh", hash160 = "2f86ddd3fac7bf830020f97c46b33aabc891e132" }
 prize = 0.172
 status = "swept"
-public_key = "02ed75f534f534c536d0732acd70af3e0d173c1f6885381edf8469d1e5a4cae716"
-pubkey_format = "compressed"
+pubkey = { value = "02ed75f534f534c536d0732acd70af3e0d173c1f6885381edf8469d1e5a4cae716", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.172 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.172 }]
 
@@ -1773,8 +1673,7 @@ key = { bits = 173 }
 address = { value = "1Mkodin3C3drVaV9JNk1o3i4n4gVGe9GVx", kind = "p2pkh", hash160 = "e3ab5452f79c3ba677d230621f865667114ace03" }
 prize = 0.173
 status = "swept"
-public_key = "0233d5bd5790203edab5c63839bee1765735c35254ec24f3073f65d99e1dabf90e"
-pubkey_format = "compressed"
+pubkey = { value = "0233d5bd5790203edab5c63839bee1765735c35254ec24f3073f65d99e1dabf90e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.173 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.173 }]
 
@@ -1783,8 +1682,7 @@ key = { bits = 174 }
 address = { value = "1C6dHU1gQtVUXZmeXQuQc3EgDJbiLbxFZJ", kind = "p2pkh", hash160 = "79b9c06f479cde2a04c871b7534f1d4706c6411a" }
 prize = 0.174
 status = "swept"
-public_key = "03c11209f91946eb81b603d046a296f5754967897d471980fe43ea1aec8bf2ad7c"
-pubkey_format = "compressed"
+pubkey = { value = "03c11209f91946eb81b603d046a296f5754967897d471980fe43ea1aec8bf2ad7c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.174 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.174 }]
 
@@ -1793,8 +1691,7 @@ key = { bits = 175 }
 address = { value = "1DxZJy7AkqLVAQ5rtSUKfrR3yPE5u5ygk6", kind = "p2pkh", hash160 = "8e235bafd009b1bf67a8475cf1687b09b23c525f" }
 prize = 0.175
 status = "swept"
-public_key = "02cb5f1f0d3dd67f0f162353490d98219982f5095bd32daa6c020806cf59ea2c2e"
-pubkey_format = "compressed"
+pubkey = { value = "02cb5f1f0d3dd67f0f162353490d98219982f5095bd32daa6c020806cf59ea2c2e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.175 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.175 }]
 
@@ -1803,8 +1700,7 @@ key = { bits = 176 }
 address = { value = "1NcytLwdqJa8DsQPa9NwkxJTQcx1rZy85A", kind = "p2pkh", hash160 = "ed28af7ebd057c69f2f9f5852fcff8da51b32571" }
 prize = 0.176
 status = "swept"
-public_key = "02ba9f479c758f5b2842ddef8414e70acfc943d2584258709352061a100e410ee4"
-pubkey_format = "compressed"
+pubkey = { value = "02ba9f479c758f5b2842ddef8414e70acfc943d2584258709352061a100e410ee4", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.176 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.176 }]
 
@@ -1813,8 +1709,7 @@ key = { bits = 177 }
 address = { value = "163vG9mKmAsrvmq42MBDPjf9axZyEgBc9R", kind = "p2pkh", hash160 = "3765ebcb90c64c4167674c8c2f35ad3d12245fb5" }
 prize = 0.177
 status = "swept"
-public_key = "028ae59ec009a07fad636a066f72d567a1fe9a37492b40688c2edfe18de00f284c"
-pubkey_format = "compressed"
+pubkey = { value = "028ae59ec009a07fad636a066f72d567a1fe9a37492b40688c2edfe18de00f284c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.177 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.177 }]
 
@@ -1823,8 +1718,7 @@ key = { bits = 178 }
 address = { value = "12ATwA5VvoPDinSymcQpCAXPLApAVLN24z", kind = "p2pkh", hash160 = "0cc25a433319a84636805fd00f8862aeb3fc8cdd" }
 prize = 0.178
 status = "swept"
-public_key = "035fd8708ca357691c50a49b0d339227360049b3156c3d32d1c54a315393bda35e"
-pubkey_format = "compressed"
+pubkey = { value = "035fd8708ca357691c50a49b0d339227360049b3156c3d32d1c54a315393bda35e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.178 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.178 }]
 
@@ -1833,8 +1727,7 @@ key = { bits = 179 }
 address = { value = "12fXbBE7kTfqYk8dYyU9bw7XfKVwEqXnzg", kind = "p2pkh", hash160 = "12417789f9448e8d151699534c43c5b419e4ab7a" }
 prize = 0.179
 status = "swept"
-public_key = "02064bbc39fd98afca5085c5e9a006c8bb0e466adef24a911e635f835c8061c15f"
-pubkey_format = "compressed"
+pubkey = { value = "02064bbc39fd98afca5085c5e9a006c8bb0e466adef24a911e635f835c8061c15f", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.179 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.179 }]
 
@@ -1843,8 +1736,7 @@ key = { bits = 180 }
 address = { value = "1EkYsB1C7deWxiVUULeZpr42AdYWhv4PEX", kind = "p2pkh", hash160 = "96d61f034c1d3db504e6c84e1d9b5e47b3bbb6ef" }
 prize = 0.18
 status = "swept"
-public_key = "0329420514190479e81640f967e686e2d950e231edd021fc63a17193dac2969a3d"
-pubkey_format = "compressed"
+pubkey = { value = "0329420514190479e81640f967e686e2d950e231edd021fc63a17193dac2969a3d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.18 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.18 }]
 
@@ -1853,8 +1745,7 @@ key = { bits = 181 }
 address = { value = "1MPQyhXBT2FpUMCiv5YX3yacKvmc9P5x6S", kind = "p2pkh", hash160 = "df9faeaaf5c84fb9aca49f923d7ae0286754f13f" }
 prize = 0.181
 status = "swept"
-public_key = "02cd62a1cefed68821c2fc3a0e763a0178a323cfba08cde5c0321caa644f1052de"
-pubkey_format = "compressed"
+pubkey = { value = "02cd62a1cefed68821c2fc3a0e763a0178a323cfba08cde5c0321caa644f1052de", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.181 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.181 }]
 
@@ -1863,8 +1754,7 @@ key = { bits = 182 }
 address = { value = "1GZyxmpgtRJNaW1zEhPAa81xZDEJSdwbbZ", kind = "p2pkh", hash160 = "aac6bf269ddce4d550f9c58eedc720b85ba1dc49" }
 prize = 0.182
 status = "swept"
-public_key = "03f7aafd4bcc8478efb01ff830655d88cb60399e3179e24eb0146b013ee5c4d6a1"
-pubkey_format = "compressed"
+pubkey = { value = "03f7aafd4bcc8478efb01ff830655d88cb60399e3179e24eb0146b013ee5c4d6a1", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.182 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.182 }]
 
@@ -1873,8 +1763,7 @@ key = { bits = 183 }
 address = { value = "12E2HWQVHzuGKAQVvPUkHWwibAJfnmcHW1", kind = "p2pkh", hash160 = "0d6e9b09e523e71ad7b9873dadee0d0bc788033c" }
 prize = 0.183
 status = "swept"
-public_key = "036d249dae9d1f3afe5c85ec6f34561a2373d6c0b6cfa8ca1b4ae00d1937e7a59b"
-pubkey_format = "compressed"
+pubkey = { value = "036d249dae9d1f3afe5c85ec6f34561a2373d6c0b6cfa8ca1b4ae00d1937e7a59b", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.183 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.183 }]
 
@@ -1883,8 +1772,7 @@ key = { bits = 184 }
 address = { value = "14J1fXY2E3fbxjp1zpfqRhk5BNQ4pb97Rs", kind = "p2pkh", hash160 = "242000d101c4c5b143c63f12ae08caa81d837c28" }
 prize = 0.184
 status = "swept"
-public_key = "0377059f597c2e14d648807db27c8540f7cdd7e176c5baf979dcc00f251bdec6aa"
-pubkey_format = "compressed"
+pubkey = { value = "0377059f597c2e14d648807db27c8540f7cdd7e176c5baf979dcc00f251bdec6aa", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.184 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.184 }]
 
@@ -1893,8 +1781,7 @@ key = { bits = 185 }
 address = { value = "1HqHHuFzZhtTtyGbAWCS49qGnCBSEhBSFT", kind = "p2pkh", hash160 = "b8a393fd03783ac177243e8c4313a4221b049b8a" }
 prize = 0.185
 status = "swept"
-public_key = "0208ce81549c729647d7747a6a7e304104435fae445afb4fa90fd384f2640f0ed9"
-pubkey_format = "compressed"
+pubkey = { value = "0208ce81549c729647d7747a6a7e304104435fae445afb4fa90fd384f2640f0ed9", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.185 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.185 }]
 
@@ -1903,8 +1790,7 @@ key = { bits = 186 }
 address = { value = "1BJXBDt4e1uaorXPototucUGNRme57nAqt", kind = "p2pkh", hash160 = "710184e0443717cc62b086824b793f4e011b4456" }
 prize = 0.186
 status = "swept"
-public_key = "03ab1c8c3d6b773758c2a765dd33fa0b9804c55754f9a9278a158a2d02a6edd1a6"
-pubkey_format = "compressed"
+pubkey = { value = "03ab1c8c3d6b773758c2a765dd33fa0b9804c55754f9a9278a158a2d02a6edd1a6", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.186 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.186 }]
 
@@ -1913,8 +1799,7 @@ key = { bits = 187 }
 address = { value = "19ct7Egfi5j6jSefj8X4d5eXJQUmyhtXjC", kind = "p2pkh", hash160 = "5e8a3a32df85af78e2ce3493985ff4ae2da00623" }
 prize = 0.187
 status = "swept"
-public_key = "028393d6e394d960b1b7e239707d87595f85b7bdca480dafd39d4797124740d9ef"
-pubkey_format = "compressed"
+pubkey = { value = "028393d6e394d960b1b7e239707d87595f85b7bdca480dafd39d4797124740d9ef", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.187 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.187 }]
 
@@ -1923,8 +1808,7 @@ key = { bits = 188 }
 address = { value = "1DyWSY1dA3wyjo4eMuQCPfrm3dV96xDDSU", kind = "p2pkh", hash160 = "8e5160f5d3f432f7421f189d1888b85ed8337180" }
 prize = 0.188
 status = "swept"
-public_key = "039705ff013b8514ee6eded8af52879598d19306f3e252f153dbfa02baa06d7dde"
-pubkey_format = "compressed"
+pubkey = { value = "039705ff013b8514ee6eded8af52879598d19306f3e252f153dbfa02baa06d7dde", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.188 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.188 }]
 
@@ -1933,8 +1817,7 @@ key = { bits = 189 }
 address = { value = "1PiLrDyeXtncnsvcVAGGcNnpzQVRCG3fwS", kind = "p2pkh", hash160 = "f92463f967ffc9cea3e1ef846ff106b591e38e68" }
 prize = 0.189
 status = "swept"
-public_key = "027a9e387d83df7847566373ef601f2b6dd9adbaf3fde5582199ed71f4b8ca9e08"
-pubkey_format = "compressed"
+pubkey = { value = "027a9e387d83df7847566373ef601f2b6dd9adbaf3fde5582199ed71f4b8ca9e08", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.189 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.189 }]
 
@@ -1943,8 +1826,7 @@ key = { bits = 190 }
 address = { value = "1HUoYzoEn2a4WxKvnYYbnR9GKrVqAfq7oY", kind = "p2pkh", hash160 = "b4c41a566543c9133f45361d6df0895319113538" }
 prize = 0.19
 status = "swept"
-public_key = "03eb37cc02df3bd83f67e581116b2e08b1b4f27354a21d6345fe17484f4ba2ab8a"
-pubkey_format = "compressed"
+pubkey = { value = "03eb37cc02df3bd83f67e581116b2e08b1b4f27354a21d6345fe17484f4ba2ab8a", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.19 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.19 }]
 
@@ -1953,8 +1835,7 @@ key = { bits = 191 }
 address = { value = "19vnME8b28SzJDuEFNShAG5JCR63V1zzV", kind = "p2pkh", hash160 = "01b038f889ed602266f2c6647f657713e52d8cac" }
 prize = 0.191
 status = "swept"
-public_key = "03bd9d14ad1d7d2c3d1f46b5f2c82142a5c0784ff4506c04ae0a99d9737e1630d1"
-pubkey_format = "compressed"
+pubkey = { value = "03bd9d14ad1d7d2c3d1f46b5f2c82142a5c0784ff4506c04ae0a99d9737e1630d1", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.191 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.191 }]
 
@@ -1963,8 +1844,7 @@ key = { bits = 192 }
 address = { value = "1GWTEv76C8cusq4h5gV3rLjeFhBkGBHSKg", kind = "p2pkh", hash160 = "aa1bda87c542102bc484b1fc54f93764f0ccd701" }
 prize = 0.192
 status = "swept"
-public_key = "024e1799de117b044ea4778a77f0a6267bb84b182f55093be7ed0e8f703b74e5bd"
-pubkey_format = "compressed"
+pubkey = { value = "024e1799de117b044ea4778a77f0a6267bb84b182f55093be7ed0e8f703b74e5bd", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.192 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.192 }]
 
@@ -1973,8 +1853,7 @@ key = { bits = 193 }
 address = { value = "1NHh2fQDm7KyBs8HRFkVtHgMzkmufk6mNW", kind = "p2pkh", hash160 = "e982b609d7049607fb087a936464fe8915087aee" }
 prize = 0.193
 status = "swept"
-public_key = "02a7cbaf2cc78bf6686b7a2a2cbcd2d0ed6e03e56f481e18212508364b682ca711"
-pubkey_format = "compressed"
+pubkey = { value = "02a7cbaf2cc78bf6686b7a2a2cbcd2d0ed6e03e56f481e18212508364b682ca711", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.193 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.193 }]
 
@@ -1983,8 +1862,7 @@ key = { bits = 194 }
 address = { value = "1oW8VFRNVKhbzzq8NWNutDYDzv1CzAHAj", kind = "p2pkh", hash160 = "08cb7331dccb902b5db0a30dcc1ba8adbd6fe4d0" }
 prize = 0.194
 status = "swept"
-public_key = "024e951c7b8d0630a84f5f79b6a8ddae01ff2166f322fc4558d20c97aacd8f2839"
-pubkey_format = "compressed"
+pubkey = { value = "024e951c7b8d0630a84f5f79b6a8ddae01ff2166f322fc4558d20c97aacd8f2839", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.194 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.194 }]
 
@@ -1993,8 +1871,7 @@ key = { bits = 195 }
 address = { value = "16q15tpaHQFUENUmRPLgiidCMWLcDpVEgs", kind = "p2pkh", hash160 = "3fecaa5f1295e3374ef2b04a365523cfcb56305a" }
 prize = 0.195
 status = "swept"
-public_key = "029cfb4b5b2830188161b359fc1fb7ef3023b3212889ee8565a7989de774af192d"
-pubkey_format = "compressed"
+pubkey = { value = "029cfb4b5b2830188161b359fc1fb7ef3023b3212889ee8565a7989de774af192d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.195 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.195 }]
 
@@ -2003,8 +1880,7 @@ key = { bits = 196 }
 address = { value = "1AH4d8Bss6eFyugZaN2qPXMBH69T946dSK", kind = "p2pkh", hash160 = "65c2cfc6b38650c00242435f1b041a5fb1b733ee" }
 prize = 0.196
 status = "swept"
-public_key = "02e56e407ea984475f21ee82e96822c541967dae2a68e85ef883ec46c7646d6f67"
-pubkey_format = "compressed"
+pubkey = { value = "02e56e407ea984475f21ee82e96822c541967dae2a68e85ef883ec46c7646d6f67", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.196 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.196 }]
 
@@ -2013,8 +1889,7 @@ key = { bits = 197 }
 address = { value = "12gDPuHvZBh6FSjyhHhyDDkM38Y2wyDGQt", kind = "p2pkh", hash160 = "1262b1eb58a0e55dc874e8c2d097e61194358388" }
 prize = 0.197
 status = "swept"
-public_key = "028ab0a2c3a3413f9ea995a2bd5c7a72b79b2c6f76bf7cf49d840028a618046fd3"
-pubkey_format = "compressed"
+pubkey = { value = "028ab0a2c3a3413f9ea995a2bd5c7a72b79b2c6f76bf7cf49d840028a618046fd3", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.197 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.197 }]
 
@@ -2023,8 +1898,7 @@ key = { bits = 198 }
 address = { value = "12jFRwZFUrxUTtuyVzw9FNJsJa7mjBgfca", kind = "p2pkh", hash160 = "12f5a4496acc2393b6b56408ae7b3e07b6dc9b93" }
 prize = 0.198
 status = "swept"
-public_key = "0245f61026852cde2db15de4b129ad0e3c54aba03ed9b0f676eb9dfb680277d569"
-pubkey_format = "compressed"
+pubkey = { value = "0245f61026852cde2db15de4b129ad0e3c54aba03ed9b0f676eb9dfb680277d569", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.198 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.198 }]
 
@@ -2033,8 +1907,7 @@ key = { bits = 199 }
 address = { value = "1BNkFNU3eJz8jDfTkTwe7XmF18BfQwfqW7", kind = "p2pkh", hash160 = "71ce182dba6c2838d69248017141117721a7200a" }
 prize = 0.199
 status = "swept"
-public_key = "03ec5cd862b5699f09e5341b4315b2a548024718fe9ce70d205dbfbbface07d7ee"
-pubkey_format = "compressed"
+pubkey = { value = "03ec5cd862b5699f09e5341b4315b2a548024718fe9ce70d205dbfbbface07d7ee", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.199 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.199 }]
 
@@ -2043,8 +1916,7 @@ key = { bits = 200 }
 address = { value = "1DEDEKJVEmXvEqwg3wbq8c1ZNobo4tNw4h", kind = "p2pkh", hash160 = "8621202a5e010769fb0fd1a08027f41e173c3bb5" }
 prize = 0.2
 status = "swept"
-public_key = "03fe993e313ad3c5e8ae4d7e99a8cd5131ae04896270e48082d5965dba9616032d"
-pubkey_format = "compressed"
+pubkey = { value = "03fe993e313ad3c5e8ae4d7e99a8cd5131ae04896270e48082d5965dba9616032d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.2 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.2 }]
 
@@ -2053,8 +1925,7 @@ key = { bits = 201 }
 address = { value = "1DA2RexqNkbVhzfkmQDHRMfKrdesgyMMdQ", kind = "p2pkh", hash160 = "85567151f330b69bac3eba86bb3aedd8813ec2b7" }
 prize = 0.201
 status = "swept"
-public_key = "03346fd1b1ca7a7eb88e4b7af48d678a42e8ca8d607d8e4e2967d16394c360d014"
-pubkey_format = "compressed"
+pubkey = { value = "03346fd1b1ca7a7eb88e4b7af48d678a42e8ca8d607d8e4e2967d16394c360d014", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.201 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.201 }]
 
@@ -2063,8 +1934,7 @@ key = { bits = 202 }
 address = { value = "19Ho5YB6y8qRCdUMxWpXqrm8N4AKAq7ZWS", kind = "p2pkh", hash160 = "5aee20366a5523246e1c43dc48462878b0d4806e" }
 prize = 0.202
 status = "swept"
-public_key = "02669d985185d1894541f6ab7ea7fd57dace5bf97f2c73736b205ab07a5685354b"
-pubkey_format = "compressed"
+pubkey = { value = "02669d985185d1894541f6ab7ea7fd57dace5bf97f2c73736b205ab07a5685354b", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.202 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.202 }]
 
@@ -2073,8 +1943,7 @@ key = { bits = 203 }
 address = { value = "1DVWn7PuRBmsdTBKiboBdSREHdAtSoN6BB", kind = "p2pkh", hash160 = "89060378aec62c83cd6e20d92865cf9ca80549b1" }
 prize = 0.203
 status = "swept"
-public_key = "034fd997afbe4608f743661ae417c5706b044d9d5532a51aef5f4cb244f5f5dce1"
-pubkey_format = "compressed"
+pubkey = { value = "034fd997afbe4608f743661ae417c5706b044d9d5532a51aef5f4cb244f5f5dce1", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.203 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.203 }]
 
@@ -2083,8 +1952,7 @@ key = { bits = 204 }
 address = { value = "14CMU6qvv55Y7xJdVw64ey5yfUP4BZAjct", kind = "p2pkh", hash160 = "230e09c32f5aa23763f8e7c770cee5b5cf4359c1" }
 prize = 0.204
 status = "swept"
-public_key = "038e2790adcbe6d0c89c0c23763c52608ad0fe2a757e9910550f45bfb1855ad54c"
-pubkey_format = "compressed"
+pubkey = { value = "038e2790adcbe6d0c89c0c23763c52608ad0fe2a757e9910550f45bfb1855ad54c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.204 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.204 }]
 
@@ -2093,8 +1961,7 @@ key = { bits = 205 }
 address = { value = "1DHL5NuXPjwDsNnXyzAgZTAMM4aYUc1zFW", kind = "p2pkh", hash160 = "86b816944ed6fce46ca955b80897996b016f8be0" }
 prize = 0.205
 status = "swept"
-public_key = "030fad8d46d7a7f4e5b5c76a09a05166c8f7515651f0c73bf8329353f412699c99"
-pubkey_format = "compressed"
+pubkey = { value = "030fad8d46d7a7f4e5b5c76a09a05166c8f7515651f0c73bf8329353f412699c99", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.205 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.205 }]
 
@@ -2103,8 +1970,7 @@ key = { bits = 206 }
 address = { value = "1UwsEPMF1NZTWJAuymsLVJpqetBZ3Q9sJ", kind = "p2pkh", hash160 = "054907e50b2feceb0b75f850fd764c197844fea0" }
 prize = 0.206
 status = "swept"
-public_key = "0291a1ff9572bcbafd8dabe85c90e10a458a4f71e759747918d4aa1f56af8a66af"
-pubkey_format = "compressed"
+pubkey = { value = "0291a1ff9572bcbafd8dabe85c90e10a458a4f71e759747918d4aa1f56af8a66af", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.206 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.206 }]
 
@@ -2113,8 +1979,7 @@ key = { bits = 207 }
 address = { value = "16aELF1f75o464ZhtAZUwbc4ctFQZxS8qi", kind = "p2pkh", hash160 = "3d217c047cabb55395cd9618cee124683ea5c998" }
 prize = 0.207
 status = "swept"
-public_key = "030fb4b479aaa51c07c2f660501ccf73a6aaef84e2065ad1dcf97125a5d7248258"
-pubkey_format = "compressed"
+pubkey = { value = "030fb4b479aaa51c07c2f660501ccf73a6aaef84e2065ad1dcf97125a5d7248258", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.207 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.207 }]
 
@@ -2123,8 +1988,7 @@ key = { bits = 208 }
 address = { value = "15TJ3wPvdviupvKQFm8hLeXSzeMSq7LSJ2", kind = "p2pkh", hash160 = "30d98d22a09bf062c9b3706af3c059a72bcb7879" }
 prize = 0.208
 status = "swept"
-public_key = "03762e52fe281f880581dcd00bf80a7fd949af3439b479aba16b6fa5b04733f4b4"
-pubkey_format = "compressed"
+pubkey = { value = "03762e52fe281f880581dcd00bf80a7fd949af3439b479aba16b6fa5b04733f4b4", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.208 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.208 }]
 
@@ -2133,8 +1997,7 @@ key = { bits = 209 }
 address = { value = "1JgrGoQbvJS7UnX6j4myiCxo6Q3gyo5Ujk", kind = "p2pkh", hash160 = "c2037dcac7d46e66c4e06c289c3ccd3170438332" }
 prize = 0.209
 status = "swept"
-public_key = "0243874c891b55668295d5fb6a734fa8b9c4f73eb80cd4f3be3ed7de520e974e9f"
-pubkey_format = "compressed"
+pubkey = { value = "0243874c891b55668295d5fb6a734fa8b9c4f73eb80cd4f3be3ed7de520e974e9f", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.209 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.209 }]
 
@@ -2143,8 +2006,7 @@ key = { bits = 210 }
 address = { value = "14Xm5DjBUQTJCzeGhyrhVsxkK8p35srk1S", kind = "p2pkh", hash160 = "26b9a572ce3f674c9c8d3a0f15386d6848783c25" }
 prize = 0.21
 status = "swept"
-public_key = "03628e54188ca8c8c0b73fdb12064f195417f9fd98a7b0763d83eda2518c526f44"
-pubkey_format = "compressed"
+pubkey = { value = "03628e54188ca8c8c0b73fdb12064f195417f9fd98a7b0763d83eda2518c526f44", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.21 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.21 }]
 
@@ -2153,8 +2015,7 @@ key = { bits = 211 }
 address = { value = "19yhSoza8oK3ioCSydMuAGJs4Mm3FwCTht", kind = "p2pkh", hash160 = "627a0fd9f1c2034f9d643a355621842288cf4551" }
 prize = 0.211
 status = "swept"
-public_key = "036f164c6a628d94338a9dc9dfc1cc2f91a3a9382c198bb05f51fbbc34c6cc583e"
-pubkey_format = "compressed"
+pubkey = { value = "036f164c6a628d94338a9dc9dfc1cc2f91a3a9382c198bb05f51fbbc34c6cc583e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.211 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.211 }]
 
@@ -2163,8 +2024,7 @@ key = { bits = 212 }
 address = { value = "1JXw9i8dEZGH29mUiuKjWXK9L27r2TerLQ", kind = "p2pkh", hash160 = "c053d1c7b2e7e27c624dcb8087549876af73aa03" }
 prize = 0.212
 status = "swept"
-public_key = "020df4abc8bae9c000ea2357b014befe3e6d13dd63951ac0b2b66b37eab76b7ead"
-pubkey_format = "compressed"
+pubkey = { value = "020df4abc8bae9c000ea2357b014befe3e6d13dd63951ac0b2b66b37eab76b7ead", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.212 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.212 }]
 
@@ -2173,8 +2033,7 @@ key = { bits = 213 }
 address = { value = "1CNNth43uiVypxHmZLC8hWZsb7UiP7wSkY", kind = "p2pkh", hash160 = "7cb4648719aedaf874354cadf986e89458eb58cc" }
 prize = 0.213
 status = "swept"
-public_key = "024b5c68b748907bc07afa2f4d9cfeef5524d0675ee4b5a39f2e9e7b7b85f2bd9f"
-pubkey_format = "compressed"
+pubkey = { value = "024b5c68b748907bc07afa2f4d9cfeef5524d0675ee4b5a39f2e9e7b7b85f2bd9f", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.213 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.213 }]
 
@@ -2183,8 +2042,7 @@ key = { bits = 214 }
 address = { value = "16ocVeZDpqcvyMvzAH1r2LR75uEzRhkyV2", kind = "p2pkh", hash160 = "3fa96459d3e03e94794724b8605c9ae47a106862" }
 prize = 0.214
 status = "swept"
-public_key = "033fb8f6eb9cd60aca4f5ec48c7bd81fbe2c221c7701bcb93be5f50a810055c965"
-pubkey_format = "compressed"
+pubkey = { value = "033fb8f6eb9cd60aca4f5ec48c7bd81fbe2c221c7701bcb93be5f50a810055c965", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.214 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.214 }]
 
@@ -2193,8 +2051,7 @@ key = { bits = 215 }
 address = { value = "15x3tRVyn9SRaxfbFUzqETmCJiz46Vs247", kind = "p2pkh", hash160 = "3649ca67657d482484f49f8f5c8cdb5222c8700f" }
 prize = 0.215
 status = "swept"
-public_key = "02dcab1861d56d3b6ca4d741f885c9f7b34d91b460f90b3dc1983acf701ca8092f"
-pubkey_format = "compressed"
+pubkey = { value = "02dcab1861d56d3b6ca4d741f885c9f7b34d91b460f90b3dc1983acf701ca8092f", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.215 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.215 }]
 
@@ -2203,8 +2060,7 @@ key = { bits = 216 }
 address = { value = "197K7MdYhnN88gcJouJRxMiSAHHfWuPrXC", kind = "p2pkh", hash160 = "58f29e811ffece9aaf65c7a360382ebcea3a2f18" }
 prize = 0.216
 status = "swept"
-public_key = "022f02cc3458301883c9bd15fe341384f94ce48076f836815f7b89901f3a27abc4"
-pubkey_format = "compressed"
+pubkey = { value = "022f02cc3458301883c9bd15fe341384f94ce48076f836815f7b89901f3a27abc4", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.216 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.216 }]
 
@@ -2213,8 +2069,7 @@ key = { bits = 217 }
 address = { value = "1MDsNYfC4LErgwUDqfQ5BgFJqv5bs4Frkn", kind = "p2pkh", hash160 = "ddd18e224de138253a990a4cc8d8e7aaa3998914" }
 prize = 0.217
 status = "swept"
-public_key = "023dccddd7460b8000e6ac7bb14f98cad9aeb4b4f858c2a655738ce141d71224fb"
-pubkey_format = "compressed"
+pubkey = { value = "023dccddd7460b8000e6ac7bb14f98cad9aeb4b4f858c2a655738ce141d71224fb", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.217 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.217 }]
 
@@ -2223,8 +2078,7 @@ key = { bits = 218 }
 address = { value = "1BDTXmiyyzq9i79RGGTW7cjmYJbxKoV27e", kind = "p2pkh", hash160 = "700c655d586d1a06b0185b12007a1b195d60271c" }
 prize = 0.218
 status = "swept"
-public_key = "03d8c17e24c72388998ebe82837a555e57d1db6162738cec8963384c367e393906"
-pubkey_format = "compressed"
+pubkey = { value = "03d8c17e24c72388998ebe82837a555e57d1db6162738cec8963384c367e393906", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.218 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.218 }]
 
@@ -2233,8 +2087,7 @@ key = { bits = 219 }
 address = { value = "1EiJ59LPWDezXwfAGFTcoEKdNhvRTriBXy", kind = "p2pkh", hash160 = "9668f0ad5f1eaa5c8e68baf1eaa07c1ea16a88de" }
 prize = 0.219
 status = "swept"
-public_key = "02ef830a543b3b50c3fc7e42bbc0938039f8d3e19a1e862012f281c51f3581d77d"
-pubkey_format = "compressed"
+pubkey = { value = "02ef830a543b3b50c3fc7e42bbc0938039f8d3e19a1e862012f281c51f3581d77d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.219 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.219 }]
 
@@ -2243,8 +2096,7 @@ key = { bits = 220 }
 address = { value = "1rirV4Y2NxGwKNQNojJhz61jEctni8fvb", kind = "p2pkh", hash160 = "096751c3cb56d4d163186085c81fc8dcf5bfa4ec" }
 prize = 0.22
 status = "swept"
-public_key = "022cc796d5a8ec2c871640152a0db6ffd2b4ea957c8f5ecf706fbc383fa5ad7696"
-pubkey_format = "compressed"
+pubkey = { value = "022cc796d5a8ec2c871640152a0db6ffd2b4ea957c8f5ecf706fbc383fa5ad7696", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.22 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.22 }]
 
@@ -2253,8 +2105,7 @@ key = { bits = 221 }
 address = { value = "1NxgWntAdMugSNFHEXYizYwk3UjxKPxcDF", kind = "p2pkh", hash160 = "f0e280f15876be99ab63c8aaa4f934f777ed369b" }
 prize = 0.221
 status = "swept"
-public_key = "028a874fe6f1ab00358d0b610d536fd67f049c98069eeb35585549250ef9fff4c5"
-pubkey_format = "compressed"
+pubkey = { value = "028a874fe6f1ab00358d0b610d536fd67f049c98069eeb35585549250ef9fff4c5", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.221 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.221 }]
 
@@ -2263,8 +2114,7 @@ key = { bits = 222 }
 address = { value = "17A75vEkPPVeY9MMMXUY9M2JUHbbNyVAWC", kind = "p2pkh", hash160 = "438993e343b3317a4833a709894145f2374a95f9" }
 prize = 0.222
 status = "swept"
-public_key = "021536a0aa8cdb5061debba4f236d311a570f6de6d483419fa23c147f543765602"
-pubkey_format = "compressed"
+pubkey = { value = "021536a0aa8cdb5061debba4f236d311a570f6de6d483419fa23c147f543765602", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.222 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.222 }]
 
@@ -2273,8 +2123,7 @@ key = { bits = 223 }
 address = { value = "1NUVBXgX35Uax4fpziV7VGMJyji3mUzZbt", kind = "p2pkh", hash160 = "eb8d65ae18eba8f6a1fcffe0b37e87fa34b09a70" }
 prize = 0.223
 status = "swept"
-public_key = "034cfb3bcb83ed739ecc9abc84f68ffaa430f2d685bebfaf8cefaaabcd2b53d984"
-pubkey_format = "compressed"
+pubkey = { value = "034cfb3bcb83ed739ecc9abc84f68ffaa430f2d685bebfaf8cefaaabcd2b53d984", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.223 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.223 }]
 
@@ -2283,8 +2132,7 @@ key = { bits = 224 }
 address = { value = "1F6yxcbDzjumeN77DiABMXzPcvtAdnaoPF", kind = "p2pkh", hash160 = "9ab3633c60100b0dd631bf1c6755abaea7bc0445" }
 prize = 0.224
 status = "swept"
-public_key = "02a1cf7a8cb1bdd05701aa57ef6e5a9ce28950d93e2369d5fa11ec5bdc8d4ce9d1"
-pubkey_format = "compressed"
+pubkey = { value = "02a1cf7a8cb1bdd05701aa57ef6e5a9ce28950d93e2369d5fa11ec5bdc8d4ce9d1", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.224 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.224 }]
 
@@ -2293,8 +2141,7 @@ key = { bits = 225 }
 address = { value = "16YvGEYhAwjf2duwvH8jbFMfVCnY6XiQTq", kind = "p2pkh", hash160 = "3ce1fc3304d09e7984c5766fd1134c1e8979821a" }
 prize = 0.225
 status = "swept"
-public_key = "03e1819c7597f314943bf847e6ec36c4c95ac1b3ead9948b90e9a2729357712ff7"
-pubkey_format = "compressed"
+pubkey = { value = "03e1819c7597f314943bf847e6ec36c4c95ac1b3ead9948b90e9a2729357712ff7", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.225 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.225 }]
 
@@ -2303,8 +2150,7 @@ key = { bits = 226 }
 address = { value = "1HtbZg9mPjYcMDMDNyXaFjHX5e7ZPUwWAp", kind = "p2pkh", hash160 = "b944142155bef6fa7280d5f7f8eae49511349ebf" }
 prize = 0.226
 status = "swept"
-public_key = "020d896eac113fac98c2a4a44b1488087b3b4c2d8f2563d2a41789f0324ad62cc7"
-pubkey_format = "compressed"
+pubkey = { value = "020d896eac113fac98c2a4a44b1488087b3b4c2d8f2563d2a41789f0324ad62cc7", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.226 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.226 }]
 
@@ -2313,8 +2159,7 @@ key = { bits = 227 }
 address = { value = "15a9nXpjnQzw2o5kmvGyKzv7anZkYFHwdK", kind = "p2pkh", hash160 = "32259030b93d8f20268aaa2c5222f9366faa2fc3" }
 prize = 0.227
 status = "swept"
-public_key = "02f73589feb03e8ed1de43cc7748111e2f1d73a2a06679951addeee165d378f23e"
-pubkey_format = "compressed"
+pubkey = { value = "02f73589feb03e8ed1de43cc7748111e2f1d73a2a06679951addeee165d378f23e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.227 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.227 }]
 
@@ -2323,8 +2168,7 @@ key = { bits = 228 }
 address = { value = "18zsQK8ezT32qCqgLJQMkhqyKNwpCP3JU3", kind = "p2pkh", hash160 = "57baa9ea3f683b444a06702492443a9057ce2c96" }
 prize = 0.228
 status = "swept"
-public_key = "037ac4f241f6ba433da340b08a081323a93c0966fca5c0757685005f8396b09628"
-pubkey_format = "compressed"
+pubkey = { value = "037ac4f241f6ba433da340b08a081323a93c0966fca5c0757685005f8396b09628", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.228 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.228 }]
 
@@ -2333,8 +2177,7 @@ key = { bits = 229 }
 address = { value = "1AaBhpTnfCin9nCrai2msXzCHoVmwkAe2N", kind = "p2pkh", hash160 = "68ffcb39707615a254428f084c859376fa7144be" }
 prize = 0.229
 status = "swept"
-public_key = "020d64789d26c0363a2f284a1cddad7b6ab7dd41d65d5afe6ce7554214d4666518"
-pubkey_format = "compressed"
+pubkey = { value = "020d64789d26c0363a2f284a1cddad7b6ab7dd41d65d5afe6ce7554214d4666518", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.229 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.229 }]
 
@@ -2343,8 +2186,7 @@ key = { bits = 230 }
 address = { value = "13Jtm1mm33Uke7PbmTBYGNZGU7rXUsVs3e", kind = "p2pkh", hash160 = "1952876e85b0e6fe7c2557c8345975fd44700f06" }
 prize = 0.23
 status = "swept"
-public_key = "0216dc9de7fd808beff7fb3bc63767ef34beb0a51b4daf40151bc346781185ceec"
-pubkey_format = "compressed"
+pubkey = { value = "0216dc9de7fd808beff7fb3bc63767ef34beb0a51b4daf40151bc346781185ceec", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.23 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.23 }]
 
@@ -2353,8 +2195,7 @@ key = { bits = 231 }
 address = { value = "18aBXRctVrWN9naDGhKrLdZViNfLJfCdbF", kind = "p2pkh", hash160 = "530f6487090bda616a7846f68160ddd886fbdf24" }
 prize = 0.231
 status = "swept"
-public_key = "0378a0cae3e8275916f41b25838e45a8f4c8829c3b1b937c1b1749fd77b23177c1"
-pubkey_format = "compressed"
+pubkey = { value = "0378a0cae3e8275916f41b25838e45a8f4c8829c3b1b937c1b1749fd77b23177c1", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.231 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.231 }]
 
@@ -2363,8 +2204,7 @@ key = { bits = 232 }
 address = { value = "1MEEjd99pkEyCdiqVSCa8Jqjaun7fsEXaG", kind = "p2pkh", hash160 = "dde3637371e3638ef51b3753c028d84902153ea8" }
 prize = 0.232
 status = "swept"
-public_key = "03d9dd7c018dcf2a57a4d6c4299983c631ff8ab32eb72b57cfcf25be5366a9ed21"
-pubkey_format = "compressed"
+pubkey = { value = "03d9dd7c018dcf2a57a4d6c4299983c631ff8ab32eb72b57cfcf25be5366a9ed21", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.232 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.232 }]
 
@@ -2373,8 +2213,7 @@ key = { bits = 233 }
 address = { value = "1NnefTEeKQQAts37cQHzVx8oPrUu8LWyUK", kind = "p2pkh", hash160 = "eefccc98b21f6748888b7b682d9f3ead55796890" }
 prize = 0.233
 status = "swept"
-public_key = "021b6cde6068c69f1156c044dabdf4cf4bef6cc4eb020ff0dc74e03633f72403a8"
-pubkey_format = "compressed"
+pubkey = { value = "021b6cde6068c69f1156c044dabdf4cf4bef6cc4eb020ff0dc74e03633f72403a8", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.233 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.233 }]
 
@@ -2383,8 +2222,7 @@ key = { bits = 234 }
 address = { value = "1FYbLcutmRbvu4yUeLmC4TES2Q3ChhXYY", kind = "p2pkh", hash160 = "02c031f6bc39053653a093d95511eb1197c5029c" }
 prize = 0.234
 status = "swept"
-public_key = "02d274968fe3b7f79074b9aad3221d71f42f4c0be9bb3a8e22e20396b9a63a847d"
-pubkey_format = "compressed"
+pubkey = { value = "02d274968fe3b7f79074b9aad3221d71f42f4c0be9bb3a8e22e20396b9a63a847d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.234 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.234 }]
 
@@ -2393,8 +2231,7 @@ key = { bits = 235 }
 address = { value = "1Pp61TfkztZ9ckpdeUVCzbyA7vMqXAVsdV", kind = "p2pkh", hash160 = "fa3a7f736604e038a0a7fe5945a114467baba159" }
 prize = 0.235
 status = "swept"
-public_key = "02df2647ed50cded7c031a702c72b5b09209e5fd4a48c7cee7bf847f88c85bf4bd"
-pubkey_format = "compressed"
+pubkey = { value = "02df2647ed50cded7c031a702c72b5b09209e5fd4a48c7cee7bf847f88c85bf4bd", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.235 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.235 }]
 
@@ -2403,8 +2240,7 @@ key = { bits = 236 }
 address = { value = "1PytbQzRaf9eTpGax3c6ofKwtbxaLLSNy1", kind = "p2pkh", hash160 = "fc152109a2102e72ae6aca2192065e909170d2c3" }
 prize = 0.236
 status = "swept"
-public_key = "03e8c806fd610232c5b68d824b3a284e213e523492657965073c54ccaa8a58e8c6"
-pubkey_format = "compressed"
+pubkey = { value = "03e8c806fd610232c5b68d824b3a284e213e523492657965073c54ccaa8a58e8c6", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.236 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.236 }]
 
@@ -2413,8 +2249,7 @@ key = { bits = 237 }
 address = { value = "194bRtNQVRq4xi26UJZYTHexvLXijpzp3e", kind = "p2pkh", hash160 = "586efe7cb41fc58c651225492e5c706a3af15d35" }
 prize = 0.237
 status = "swept"
-public_key = "0288bc8b2d55ebc48d906478e7c37a78899632543dce63e6a9330a0a0c933e2095"
-pubkey_format = "compressed"
+pubkey = { value = "0288bc8b2d55ebc48d906478e7c37a78899632543dce63e6a9330a0a0c933e2095", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.237 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.237 }]
 
@@ -2423,8 +2258,7 @@ key = { bits = 238 }
 address = { value = "1DxBvzRMdvzop21DhnDJv4xJDYFGVtu7KZ", kind = "p2pkh", hash160 = "8e11830db460be44112d0d0150016fed31172246" }
 prize = 0.238
 status = "swept"
-public_key = "039a1c77eb960be561f622d14ad0de0d2660245e629c1b11033f769aec28270b77"
-pubkey_format = "compressed"
+pubkey = { value = "039a1c77eb960be561f622d14ad0de0d2660245e629c1b11033f769aec28270b77", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.238 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.238 }]
 
@@ -2433,8 +2267,7 @@ key = { bits = 239 }
 address = { value = "1QLHLvM6XKwygyWqo2cCPbfbf6woZzGEKH", kind = "p2pkh", hash160 = "fff0706a3d7d599d40406165ad0daaa0fe9dfc9f" }
 prize = 0.239
 status = "swept"
-public_key = "02dd983a8c8c8c25d3a16b014ad3e09b8188a3dc0333fc3d4b1504b1d3013b344e"
-pubkey_format = "compressed"
+pubkey = { value = "02dd983a8c8c8c25d3a16b014ad3e09b8188a3dc0333fc3d4b1504b1d3013b344e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.239 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.239 }]
 
@@ -2443,8 +2276,7 @@ key = { bits = 240 }
 address = { value = "1C8Hw6T5jypz92cNFr9Lkx4Xmr4DtP7zGA", kind = "p2pkh", hash160 = "7a0a6e15efc2350d3dd45b88d855062a810ca619" }
 prize = 0.24
 status = "swept"
-public_key = "03d569cafd2c67ce649d9b3484ae8cd392ad7019f0b7963fac095912d545070466"
-pubkey_format = "compressed"
+pubkey = { value = "03d569cafd2c67ce649d9b3484ae8cd392ad7019f0b7963fac095912d545070466", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.24 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.24 }]
 
@@ -2453,8 +2285,7 @@ key = { bits = 241 }
 address = { value = "1L7ZNx5gFPvdVPfdgFBnEUgA64woQwopqr", kind = "p2pkh", hash160 = "d1a7e9f072b3ebc159327bec2f9ed46362a85bc9" }
 prize = 0.241
 status = "swept"
-public_key = "03fbf9615ddcc9c0c9e88fb69ed62465ba694f4694f0ea94a7f3476dbf666ba56d"
-pubkey_format = "compressed"
+pubkey = { value = "03fbf9615ddcc9c0c9e88fb69ed62465ba694f4694f0ea94a7f3476dbf666ba56d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.241 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.241 }]
 
@@ -2463,8 +2294,7 @@ key = { bits = 242 }
 address = { value = "1EMhTbC4Kp8DYBk5zoLsTqZ2YakhiTgQYh", kind = "p2pkh", hash160 = "9283ba38d0bb048fb69d6aafc9a32b666f1c0977" }
 prize = 0.242
 status = "swept"
-public_key = "0387d4589510248cb352b5c82d7ee75454c507574cb281042eaf5dee2547abd2b2"
-pubkey_format = "compressed"
+pubkey = { value = "0387d4589510248cb352b5c82d7ee75454c507574cb281042eaf5dee2547abd2b2", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.242 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.242 }]
 
@@ -2473,8 +2303,7 @@ key = { bits = 243 }
 address = { value = "19CqmBBJ3H8FjxSSeSjv2Kn1cVQFXMY6AM", kind = "p2pkh", hash160 = "59fe4938c08cfa18b39d68a376ed2c065a98a55a" }
 prize = 0.243
 status = "swept"
-public_key = "0243609cd608d2d4744f3b11ff57875067ff2ac9966b87edc24e2daf2c784fc97d"
-pubkey_format = "compressed"
+pubkey = { value = "0243609cd608d2d4744f3b11ff57875067ff2ac9966b87edc24e2daf2c784fc97d", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.243 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.243 }]
 
@@ -2483,8 +2312,7 @@ key = { bits = 244 }
 address = { value = "1KMHDrCGho2QuK59UNvfjuiPdDZSgRbneC", kind = "p2pkh", hash160 = "c9481fd7d3d294113c5e53990d9451e32844c0ec" }
 prize = 0.244
 status = "swept"
-public_key = "02eaa8294f7cba1ddf4a990032a2a6d9f07eef4309ab1a27a3446f591efe189314"
-pubkey_format = "compressed"
+pubkey = { value = "02eaa8294f7cba1ddf4a990032a2a6d9f07eef4309ab1a27a3446f591efe189314", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.244 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.244 }]
 
@@ -2493,8 +2321,7 @@ key = { bits = 245 }
 address = { value = "1HzpmnHxpu4tCJ23ZS9TfWCoX8mXfpdHiq", kind = "p2pkh", hash160 = "ba7199b9bcac99a8ee39e6f103ab3cb049e7dd86" }
 prize = 0.245
 status = "swept"
-public_key = "03c763aeffae32371612f8585c10710aaf7bf4a211a632c8a18b969a4f4e42db54"
-pubkey_format = "compressed"
+pubkey = { value = "03c763aeffae32371612f8585c10710aaf7bf4a211a632c8a18b969a4f4e42db54", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.245 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.245 }]
 
@@ -2503,8 +2330,7 @@ key = { bits = 246 }
 address = { value = "1LrrNP28PYg1N1z5Uo1gR8cmoPc8h4orBZ", kind = "p2pkh", hash160 = "d9d7fb9cf1d10075b0515591e2570c7efabc80c1" }
 prize = 0.246
 status = "swept"
-public_key = "0396ba2cc3d83caad1a3970670557417e627b7cf32ba4e6219604f8f5e7ca09752"
-pubkey_format = "compressed"
+pubkey = { value = "0396ba2cc3d83caad1a3970670557417e627b7cf32ba4e6219604f8f5e7ca09752", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.246 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.246 }]
 
@@ -2513,8 +2339,7 @@ key = { bits = 247 }
 address = { value = "14D2d3WnHThUxyPhGoj2AabBTxpZcoHy3t", kind = "p2pkh", hash160 = "232eb8ef367fc06217fbaa43848df87567b2696d" }
 prize = 0.247
 status = "swept"
-public_key = "03c3f97e2896f15b0dbe0dcf12fe9ef3d62af375d683a4a93761d3f31785971dd3"
-pubkey_format = "compressed"
+pubkey = { value = "03c3f97e2896f15b0dbe0dcf12fe9ef3d62af375d683a4a93761d3f31785971dd3", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.247 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.247 }]
 
@@ -2523,8 +2348,7 @@ key = { bits = 248 }
 address = { value = "18oqrdP6uBKsn57gvmWzLuKMAY4ShapiAU", kind = "p2pkh", hash160 = "55a4cc2020c1769dce6c05e560bcff5db9f27f3a" }
 prize = 0.248
 status = "swept"
-public_key = "031037fc1784819309a913864372322768fee8ba8c3d3bf0566936096dab4157db"
-pubkey_format = "compressed"
+pubkey = { value = "031037fc1784819309a913864372322768fee8ba8c3d3bf0566936096dab4157db", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.248 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.248 }]
 
@@ -2533,8 +2357,7 @@ key = { bits = 249 }
 address = { value = "1Bun4VzuBJ7SUoQn97dinVfDyWAS336Ldg", kind = "p2pkh", hash160 = "77ac8098d4726a592aed489e3880c23cfaf719ae" }
 prize = 0.249
 status = "swept"
-public_key = "02d1d5728abc050fc1c5fefc276616e50573139f89fdd01ac4ce2e52a19f945f8c"
-pubkey_format = "compressed"
+pubkey = { value = "02d1d5728abc050fc1c5fefc276616e50573139f89fdd01ac4ce2e52a19f945f8c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.249 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.249 }]
 
@@ -2543,8 +2366,7 @@ key = { bits = 250 }
 address = { value = "1Ruu3JwvGeSmhQV9GzWAnyLCz6g3evmTY", kind = "p2pkh", hash160 = "04b623b48cc42741d0c9ec3b1fa297664bcec49b" }
 prize = 0.25
 status = "swept"
-public_key = "0230465312b31af6b26c64d58ebc8a890c41f52f57a5c0eb305d83b0351c4bf968"
-pubkey_format = "compressed"
+pubkey = { value = "0230465312b31af6b26c64d58ebc8a890c41f52f57a5c0eb305d83b0351c4bf968", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.25 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.25 }]
 
@@ -2553,8 +2375,7 @@ key = { bits = 251 }
 address = { value = "1M3u4q5Q35qtQPmDHeubVbk7APYi3VVoBX", kind = "p2pkh", hash160 = "dbeecf6406c1569a483a88e35ed349a521a414ca" }
 prize = 0.251
 status = "swept"
-public_key = "02ec2ca969860c67210de88b622f37fd4c02488d8ff9cc879ae91405523724eb0e"
-pubkey_format = "compressed"
+pubkey = { value = "02ec2ca969860c67210de88b622f37fd4c02488d8ff9cc879ae91405523724eb0e", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.251 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.251 }]
 
@@ -2563,8 +2384,7 @@ key = { bits = 252 }
 address = { value = "1CaTxB3YwmXZkDnTK4rRvq61SRqs48xmui", kind = "p2pkh", hash160 = "7efd9baf1d6e21bd5f920e7e9e468b5a45ec92c7" }
 prize = 0.252
 status = "swept"
-public_key = "0316bbf51b1574f580cd5ec84fe2371b4fd5644637b713f3a795474a1be794001c"
-pubkey_format = "compressed"
+pubkey = { value = "0316bbf51b1574f580cd5ec84fe2371b4fd5644637b713f3a795474a1be794001c", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.252 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.252 }]
 
@@ -2573,8 +2393,7 @@ key = { bits = 253 }
 address = { value = "1JqRqUPHHcQu2yrr8JZzxSYDx2jbZxEqFj", kind = "p2pkh", hash160 = "c3a2d618736baf0d5df7d81d5b8235cf8a266448" }
 prize = 0.253
 status = "swept"
-public_key = "0322ae607614dedc7261f4214dada55f1a0f11926174c3bf1689351c1783f3da48"
-pubkey_format = "compressed"
+pubkey = { value = "0322ae607614dedc7261f4214dada55f1a0f11926174c3bf1689351c1783f3da48", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.253 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.253 }]
 
@@ -2583,8 +2402,7 @@ key = { bits = 254 }
 address = { value = "1NKkjFvXmovmjwgUujw655n3BbEvnncyza", kind = "p2pkh", hash160 = "e9e6a1ad0ddaf3c372e2e1eae83c8cf9f9163b3a" }
 prize = 0.254
 status = "swept"
-public_key = "0255d81444d53e97bf282ed8c505a686ca08d270493404c1db86e64b9494ee36cf"
-pubkey_format = "compressed"
+pubkey = { value = "0255d81444d53e97bf282ed8c505a686ca08d270493404c1db86e64b9494ee36cf", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.254 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.254 }]
 
@@ -2593,8 +2411,7 @@ key = { bits = 255 }
 address = { value = "17PEUvQmgqPkkvRkMowoR1wRDXYzre4b9Z", kind = "p2pkh", hash160 = "460528d920ce045d9f6fc319182960707b248064" }
 prize = 0.255
 status = "swept"
-public_key = "030cea4a0ee0a03b7a5f77b85bb455b10979c2220f0e470ce5e0d4e0c786c04f66"
-pubkey_format = "compressed"
+pubkey = { value = "030cea4a0ee0a03b7a5f77b85bb455b10979c2220f0e470ce5e0d4e0c786c04f66", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.255 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.255 }]
 
@@ -2603,7 +2420,6 @@ key = { bits = 256 }
 address = { value = "1FMcotmnqqE5M2x9DDX3VfPAPuBWArGisa", kind = "p2pkh", hash160 = "9d77f8bcfd56b6a095703aae85bbe003a9cff5eb" }
 prize = 0.256
 status = "swept"
-public_key = "029125aed5e5342de7c6163a4158a716ac982ba7d2ed85835c6ff99c68702ce710"
-pubkey_format = "compressed"
+pubkey = { value = "029125aed5e5342de7c6163a4158a716ac982ba7d2ed85835c6ff99c68702ce710", format = "compressed" }
 start_date = "2015-01-15 18:07:14"
 transactions = [{ type = "funding", txid = "08389f34c98c606322740c0be6a7125d9860bb8d5cb182c02f98461e5fa6cd15", date = "2015-01-15 18:07:14", amount = 0.256 }, { type = "sweep", txid = "5d45587cfd1d5b0fb826805541da7d94c61fe432259e68ee26f4a04544384164", date = "2017-07-11 05:00:53", amount = 0.256 }]

--- a/data/ballet.toml
+++ b/data/ballet.toml
@@ -13,8 +13,7 @@ source_url = "https://x.com/bobbyclee/status/1289004702122643456"
 [[puzzles]]
 name = "AA007448"
 address = { value = "1LL6Xy92LwGDRfQP9fBU7f1477cEKctr7c", kind = "p2pkh", hash160 = "d406e9a3e9969c600cf2075631600d2079e5fe40" }
-public_key = "0351a7b8675ac06922080803608908267ec7f5bf93ecdd78969083647ac8a67d0d"
-pubkey_format = "compressed"
+pubkey = { value = "0351a7b8675ac06922080803608908267ec7f5bf93ecdd78969083647ac8a67d0d", format = "compressed" }
 status = "solved"
 prize = 0.00110000
 start_date = "2020-07-24 05:46:12"

--- a/data/bitaps.toml
+++ b/data/bitaps.toml
@@ -15,8 +15,7 @@ status = "unsolved"
 prize = 1.00016404
 start_date = "2020-06-19 13:24:41"
 source_url = "https://bitaps.com/mnemonic/challenge"
-public_key = "0385a3a591451ed7ed6c90dae882db918107d6f906d270cf4728d168126e0e89aa"
-pubkey_format = "compressed"
+pubkey = { value = "0385a3a591451ed7ed6c90dae882db918107d6f906d270cf4728d168126e0e89aa", format = "compressed" }
 
 [puzzle.key.seed]
 path = "m/84'/0'/0'/0/0"

--- a/data/gsmg.toml
+++ b/data/gsmg.toml
@@ -13,8 +13,7 @@ source_url = "https://gsmg.io/puzzle"
 address = { value = "1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe", kind = "p2pkh", hash160 = "a9553269572a317e39f0f518cb87c1a0ee1dbae4" }
 status = "unsolved"
 prize = 1.25364181
-public_key = "04f4d1bbd91e65e2a019566a17574e97dae908b784b388891848007e4f55d5a4649c73d25fc5ed8fd7227cab0be4e576c0c6404db5aa546286563e4be12bf33559"
-pubkey_format = "uncompressed"
+pubkey = { value = "04f4d1bbd91e65e2a019566a17574e97dae908b784b388891848007e4f55d5a4649c73d25fc5ed8fd7227cab0be4e576c0c6404db5aa546286563e4be12bf33559", format = "uncompressed" }
 start_date = "2019-04-13 16:32:40"
 transactions = [{ type = "funding", txid = "73e48ff571a7e9a4387574a50cf2fcb7b21b6ea5702c777a035664df57cbce02", date = "2019-04-13 16:32:40", amount = 5.0 }, { type = "decrease", txid = "2aa9a4a90be819d5122d70c993280785a0508f163521e7b38cebb4db0b071b13", date = "2020-05-11 20:02:50", amount = 2.5 }, { type = "decrease", txid = "88cdb3cdca12b471551b1b26188508a14ca5fd8a415223ffb7c190381c9b9df3", date = "2024-04-24 21:47:27", amount = 1.25 }]
 

--- a/data/zden.toml
+++ b/data/zden.toml
@@ -16,8 +16,7 @@ source_url = "https://crypto.haluska.sk/"
 name = "Level 1"
 chain = "bitcoin"
 address = { value = "1cryptommoqPHVNHuxVQG3bzujnRJYB1D", kind = "p2pkh", hash160 = "06c84797d2e333a2e692bb1c248f2cb20be50852" }
-public_key = "0408fe136fc5f5ab550da96673c050c539ce9877ec69965dde958d080cc4a2b896d6db9afd83e05875a401edcbc0e870c23251cb12b55677dba04a495806fd9fb7"
-pubkey_format = "uncompressed"
+pubkey = { value = "0408fe136fc5f5ab550da96673c050c539ce9877ec69965dde958d080cc4a2b896d6db9afd83e05875a401edcbc0e870c23251cb12b55677dba04a495806fd9fb7", format = "uncompressed" }
 key = { bits = 255, hex = "46c92e7276ae95778df0d7a248ab736cb6275190ded54438377a2e4b0d42a096", wif = { decrypted = "5JMTiDVHj3pj8VfaTe6pDtD9byZr6too3PD3AGBJrXF1hVsitc8" } }
 status = "solved"
 prize = 0.0260414

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -431,7 +431,7 @@ fn print_puzzle_detail_table(p: &Puzzle, show_transactions: bool) {
         rows.push(section("Public Key"));
         rows.push(KeyValueRow {
             field: "  Key".to_string(),
-            value: pubkey.key.to_string(),
+            value: pubkey.value.to_string(),
         });
         rows.push(KeyValueRow {
             field: "  Format".to_string(),
@@ -838,7 +838,7 @@ fn cmd_range(puzzle_number: u32, format: OutputFormat) {
                 start: format!("0x{:x}", start),
                 end: format!("0x{:x}", end),
                 address: Some(p.address.value.to_string()),
-                pubkey: p.pubkey.map(|pk| pk.key.to_string()),
+                pubkey: p.pubkey.map(|pk| pk.value.to_string()),
             };
             output_range(&range, format);
         }

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -253,7 +253,7 @@ pub struct Solver {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Pubkey {
-    pub key: &'static str,
+    pub value: &'static str,
     pub format: PubkeyFormat,
 }
 
@@ -366,7 +366,7 @@ impl Puzzle {
     }
 
     pub fn pubkey_str(&self) -> Option<&'static str> {
-        self.pubkey.map(|p| p.key)
+        self.pubkey.map(|p| p.value)
     }
 
     pub fn has_private_key(&self) -> bool {

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -402,7 +402,7 @@ fn gsmg_has_uncompressed_pubkey() {
     let pubkey = puzzle.pubkey.expect("GSMG should have pubkey");
     assert_eq!(pubkey.format, PubkeyFormat::Uncompressed);
     assert_eq!(
-        pubkey.key,
+        pubkey.value,
         "04f4d1bbd91e65e2a019566a17574e97dae908b784b388891848007e4f55d5a4649c73d25fc5ed8fd7227cab0be4e576c0c6404db5aa546286563e4be12bf33559"
     );
 }
@@ -428,7 +428,7 @@ fn pubkey_format_matches_key_length() {
             match pubkey.format {
                 PubkeyFormat::Compressed => {
                     assert_eq!(
-                        pubkey.key.len(),
+                        pubkey.value.len(),
                         66,
                         "Compressed pubkey should be 66 hex chars: {}",
                         puzzle.id
@@ -436,7 +436,7 @@ fn pubkey_format_matches_key_length() {
                 }
                 PubkeyFormat::Uncompressed => {
                     assert_eq!(
-                        pubkey.key.len(),
+                        pubkey.value.len(),
                         130,
                         "Uncompressed pubkey should be 130 hex chars: {}",
                         puzzle.id
@@ -452,7 +452,7 @@ fn pubkey_has_non_empty_key() {
     for puzzle in boha::all() {
         if let Some(pubkey) = &puzzle.pubkey {
             assert!(
-                !pubkey.key.is_empty(),
+                !pubkey.value.is_empty(),
                 "Puzzle {} has empty pubkey",
                 puzzle.id
             );
@@ -606,7 +606,7 @@ fn redeem_script_hash_matches_script() {
 fn pubkey_matches_hash160() {
     for puzzle in boha::all() {
         if let (Some(pubkey), Some(expected)) = (&puzzle.pubkey, puzzle.address.hash160) {
-            let computed = hash160(pubkey.key).unwrap_or_else(|| {
+            let computed = hash160(pubkey.value).unwrap_or_else(|| {
                 panic!("Failed to compute hash160 from pubkey for {}", puzzle.id)
             });
             assert_eq!(


### PR DESCRIPTION
## Summary
Improves semantic clarity by renaming `Pubkey.key` to `Pubkey.value` and restructuring TOML format to use inline tables.

Closes #82

## Changes
- Rename `Pubkey.key` → `Pubkey.value` in Rust struct
- Add `TomlPubkey` struct in build.rs for proper TOML deserialization
- Convert TOML format from two fields (`public_key` + `pubkey_format`) to inline table (`pubkey = { value, format }`)
- Add `format_pubkey()` helper function for DRY code generation
- Update cli.rs and validation.rs to use new field name

## Testing
- `cargo build --all-features` ✓
- `cargo test --all-features` - 116 passed

---
Co-Authored-By: Aei <aei@oad.earth>