### PR TITLE
feat(build): embed data version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi-str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +226,7 @@ dependencies = [
  "bech32",
  "bip38",
  "bs58",
+ "chrono",
  "clap",
  "csv",
  "dotenvy",
@@ -295,6 +305,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "cipher"
@@ -915,6 +938,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ sha2 = "0.10"
 ripemd = "0.1"
 k256 = { version = "0.13", features = ["ecdsa"] }
 bip38 = "1.1"
+chrono = "0.4"
 
 [features]
 default = []

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ enum OutputFormat {
 #[derive(Parser)]
 #[command(name = "boha")]
 #[command(about = "Crypto bounties, puzzles and challenges data")]
-#[command(version)]
+#[command(version = boha::version::FULL_VERSION)]
 struct Cli {
     /// Output format
     #[arg(short, long, value_enum, default_value = "table", global = true)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ mod puzzle;
 #[cfg(feature = "balance")]
 pub mod balance;
 
+pub mod version {
+    include!(concat!(env!("OUT_DIR"), "/data_version.rs"));
+}
+
 pub use collections::{b1000, ballet, bitaps, bitimage, gsmg, hash_collision, zden};
 pub use puzzle::{
     Address, Assets, Author, Chain, Entropy, EntropySource, IntoPuzzleNum, Key, Passphrase,


### PR DESCRIPTION
## Summary

Adds version tracking for compiled data snapshots so downstream users can trace exactly which data they're running.

Closes #96

## Changes

- Add `generate_data_version()` in build.rs that captures git hash, data hash, and build date
- Expose constants via `boha::version` module
- Update CLI `--version` to show: `0.14.0 (data: abc1234-f64d1ccb, 2026-01-20)`

## Testing

```bash
cargo run --features cli -- --version
# boha 0.14.0 (data: 7c7eba8-f64d1ccb, 2026-01-20)
```

---
Co-Authored-By: Aei <aei@oad.earth>