### PR TITLE
refactor(zden): snake_case names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ boha show gsmg
 boha show hash_collision/sha256
 
 # Show puzzle and open asset in browser
-boha show zden/Level\ 4 --open
+boha show zden/level_4 --open
 
 # Get key range
 boha range 90
@@ -125,13 +125,13 @@ let unsolved: Vec<_> = b1000::all()
 
 let gsmg_puzzle = gsmg::get();
 let sha256 = hash_collision::get("sha256").unwrap();
-let level1 = zden::get("Level 1").unwrap();
+let level1 = zden::get("level_1").unwrap();
 
 let puzzle = boha::get("b1000/90").unwrap();
 let puzzle = boha::get("gsmg").unwrap();
 let puzzle = boha::get("bitaps").unwrap();
 let puzzle = boha::get("bitimage/kitten").unwrap();
-let puzzle = boha::get("zden/Level 1").unwrap();
+let puzzle = boha::get("zden/level_1").unwrap();
 
 // Access puzzle assets (images, hints)
 if let Some(path) = puzzle.asset_path() {
@@ -255,8 +255,8 @@ assets/
 Access via library:
 
 ```rust
-let puzzle = zden::get("Level 4").unwrap();
-println!("{}", puzzle.asset_path().unwrap());  // assets/zden/level-4/puzzle.png
+let puzzle = zden::get("level_4").unwrap();
+println!("{}", puzzle.asset_path().unwrap());  // assets/zden/level_4/puzzle.png
 println!("{}", puzzle.asset_url().unwrap());   // https://raw.githubusercontent.com/...
 ```
 

--- a/data/schemas/collection.schema.json
+++ b/data/schemas/collection.schema.json
@@ -107,7 +107,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Puzzle name/identifier"
+          "pattern": "^[a-zA-Z0-9_]+$",
+          "description": "Puzzle name/identifier (alphanumeric and underscores only, no spaces)"
         },
         "chain": {
           "$ref": "./definitions.schema.json#/$defs/chain"

--- a/data/zden.jsonc
+++ b/data/zden.jsonc
@@ -15,7 +15,7 @@
   },
   "puzzles": [
     {
-      "name": "Level 1",
+      "name": "level_1",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptommoqPHVNHuxVQG3bzujnRJYB1D",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "name": "Level 2",
+      "name": "level_2",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptoTuax4qeedzVC35eYf4c16v4reJ",
@@ -107,7 +107,7 @@
       }
     },
     {
-      "name": "Level 3",
+      "name": "level_3",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptoJzomVVJUSys8Qv1gKPCXFoZy1U",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "name": "Level 4",
+      "name": "level_4",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptoRMRnj7Q9fgToxTRvejLnx3QRPq",
@@ -183,7 +183,7 @@
       }
     },
     {
-      "name": "Level 5",
+      "name": "level_5",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptoGeCRiTzVgxBQcKFFjSVydN1GW7",
@@ -226,7 +226,7 @@
       }
     },
     {
-      "name": "Level HALV",
+      "name": "level_halv",
       "chain": "bitcoin",
       "address": {
         "value": "1crypto24HCr178iMcKd5iUi5D4rsg1nK",
@@ -251,7 +251,7 @@
       }
     },
     {
-      "name": "Level SFX",
+      "name": "level_sfx",
       "chain": "bitcoin",
       "address": {
         "value": "1crypto92aYKxdzD6VSAKwpEJnXcA2s9t",
@@ -297,7 +297,7 @@
       }
     },
     {
-      "name": "Level XM17",
+      "name": "level_xm17",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptozWJAE7UzDZF1eSgsT7mVjUsu7g",
@@ -331,7 +331,7 @@
       }
     },
     {
-      "name": "1BiTCoiN WHiTe PaPeR",
+      "name": "1bitcoin_white_paper",
       "chain": "bitcoin",
       "address": {
         "value": "1BiTCoiNsuFnkCFGkv6AGgwWxN31GUwY6W",
@@ -365,7 +365,7 @@
       }
     },
     {
-      "name": "Demobit 2018",
+      "name": "demobit_2018",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptotnptVK1ZbpZFyEqcR5EVp5hjfk",
@@ -405,7 +405,7 @@
       }
     },
     {
-      "name": "Nethemba",
+      "name": "nethemba",
       "chain": "bitcoin",
       "address": {
         "value": "1cryptoP5yMdKcz1bjzUqnbs3LsasVRX6",
@@ -439,7 +439,7 @@
       }
     },
     {
-      "name": "XIXOIO",
+      "name": "xixoio",
       "chain": "ethereum",
       "address": {
         "value": "0x5d663791e869ca70c71e0a5f4cfd707f596265aa",
@@ -472,7 +472,7 @@
       }
     },
     {
-      "name": "Codex Protocol",
+      "name": "codex_protocol",
       "chain": "ethereum",
       "address": {
         "value": "0x6b2560b34c7469c561a8fce581c88bfb8cce73b2",
@@ -505,7 +505,7 @@
       }
     },
     {
-      "name": "Litecoin SegWit",
+      "name": "litecoin_segwit",
       "chain": "litecoin",
       "address": {
         "value": "LartGjF6UjmvmF1JXBhFf5wtM9uZX7LzeS",
@@ -569,7 +569,7 @@
       }
     },
     {
-      "name": "Decred Janus",
+      "name": "decred_janus",
       "chain": "decred",
       "address": {
         "value": "DsRaAja82UvgnqYaBHYFuyCKURFX2rCyEJ8",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -559,7 +559,7 @@ mod search {
             .assert()
             .success()
             .stdout(predicate::str::contains("zden/"))
-            .stdout(predicate::str::contains("Level"))
+            .stdout(predicate::str::contains("level_"))
             .stdout(predicate::str::contains("b1000/").not())
             .stdout(predicate::str::contains("hash_collision/").not());
     }

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1178,15 +1178,15 @@ fn zden_count() {
 
 #[test]
 fn zden_get_by_name() {
-    let level1 = zden::get("Level 1").unwrap();
+    let level1 = zden::get("level_1").unwrap();
     assert_eq!(level1.address.value, "1cryptommoqPHVNHuxVQG3bzujnRJYB1D");
     assert_eq!(level1.status, Status::Solved);
     assert_eq!(level1.chain, Chain::Bitcoin);
 
-    let xixoio = zden::get("XIXOIO").unwrap();
+    let xixoio = zden::get("xixoio").unwrap();
     assert_eq!(xixoio.chain, Chain::Ethereum);
 
-    let ltc = zden::get("Litecoin SegWit").unwrap();
+    let ltc = zden::get("litecoin_segwit").unwrap();
     assert_eq!(ltc.chain, Chain::Litecoin);
 }
 
@@ -1235,9 +1235,9 @@ fn zden_eth_dcr_no_hash160() {
 
 #[test]
 fn universal_get_works_with_zden() {
-    assert!(boha::get("zden/Level 1").is_ok());
-    assert!(boha::get("zden/XIXOIO").is_ok());
-    assert!(boha::get("zden/Litecoin SegWit").is_ok());
+    assert!(boha::get("zden/level_1").is_ok());
+    assert!(boha::get("zden/xixoio").is_ok());
+    assert!(boha::get("zden/litecoin_segwit").is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Normalize all 15 zden puzzle identifiers to snake_case for consistency with every other collection.

Closes #113

## Changes
- Rename all zden puzzle names in `data/zden.jsonc` (e.g. `Level 1` → `level_1`, `1BiTCoiN WHiTe PaPeR` → `1bitcoin_white_paper`)
- Add `^[a-zA-Z0-9_]+$` pattern constraint to schema `name` field
- Update tests and README examples

## Breaking
Puzzle IDs change — `zden::get("Level 1")` becomes `zden::get("level_1")`.

## Testing
`just test` — 86 CLI + 117 validation tests pass. `just clippy` clean.

---
Co-Authored-By: Aei <256851514+aeitwoen@users.noreply.github.com>