### PR TITLE
fix(cli): support ballet in author command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1310,6 +1310,7 @@ fn cmd_author(collection: &str, format: OutputFormat) {
     let author = match collection {
         "arweave" => arweave::author(),
         "b1000" => b1000::author(),
+        "ballet" => ballet::author(),
         "bitaps" => bitaps::author(),
         "bitimage" => bitimage::author(),
         "gsmg" => gsmg::author(),
@@ -1317,7 +1318,7 @@ fn cmd_author(collection: &str, format: OutputFormat) {
         "zden" => zden::author(),
         _ => {
             eprintln!(
-                "{} Unknown collection: {}. Use: arweave, b1000, bitaps, bitimage, gsmg, hash_collision (peter_todd), zden",
+                "{} Unknown collection: {}. Use: arweave, b1000, ballet, bitaps, bitimage, gsmg, hash_collision (peter_todd), zden",
                 "Error:".red().bold(),
                 collection
             );

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -87,6 +87,16 @@ mod list {
     }
 
     #[test]
+    fn ballet_collection() {
+        boha()
+            .args(["list", "ballet"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("ballet/"))
+            .stdout(predicate::str::contains("AA007448"));
+    }
+
+    #[test]
     fn gsmg_collection() {
         boha()
             .args(["list", "gsmg"])
@@ -288,6 +298,16 @@ mod author {
             .success()
             .stdout(predicate::str::contains("GSMG.io"))
             .stdout(predicate::str::contains("https://gsmg.io/puzzle"));
+    }
+
+    #[test]
+    fn ballet_author() {
+        boha()
+            .args(["author", "ballet"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Bobby Lee"))
+            .stdout(predicate::str::contains("https://x.com/bobbyclee"));
     }
 
     #[test]
@@ -562,6 +582,16 @@ mod search {
             .stdout(predicate::str::contains("level_"))
             .stdout(predicate::str::contains("b1000/").not())
             .stdout(predicate::str::contains("hash_collision/").not());
+    }
+
+    #[test]
+    fn collection_filter_ballet() {
+        boha()
+            .args(["search", "--collection", "ballet", "AA00"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("ballet/"))
+            .stdout(predicate::str::contains("b1000/").not());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -93,6 +93,7 @@ mod list {
             .assert()
             .success()
             .stdout(predicate::str::contains("ballet/"))
+            .stdout(predicate::str::contains("b1000/").not())
             .stdout(predicate::str::contains("AA007448"));
     }
 
@@ -587,7 +588,13 @@ mod search {
     #[test]
     fn collection_filter_ballet() {
         boha()
-            .args(["search", "--collection", "ballet", "AA00"])
+            .args(["search", "00"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("b1000/"));
+
+        boha()
+            .args(["search", "--collection", "ballet", "00"])
             .assert()
             .success()
             .stdout(predicate::str::contains("ballet/"))


### PR DESCRIPTION
Fixes #115.

I was checking collection-level CLI commands and noticed author ballet was still failing even though list and search --collection already support ballet. This patch wires ballet into cmd_author, updates the valid-collections error text, and adds regression coverage for ballet in list/search/author CLI tests so this path stays covered.