### PR TITLE
test: i32 IntoPuzzleNum edge cases

### DIFF
--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -522,4 +522,11 @@ mod tests {
         assert!(!Status::Claimed.is_active());
         assert!(!Status::Swept.is_active());
     }
+
+    #[test]
+    fn test_into_puzzle_num_i32() {
+        assert_eq!((-1i32).into_puzzle_num(), None);
+        assert_eq!(0i32.into_puzzle_num(), None);
+        assert_eq!(1i32.into_puzzle_num(), Some(1));
+    }
 }


### PR DESCRIPTION
Adds focused coverage for IntoPuzzleNum on i32 boundary inputs. The test checks that -1 and 0 return None, and 1 returns Some(1), so regressions in signed input handling are caught early.

*PR created automatically by Jules for task [6443818981074801990](https://jules.google.com/task/6443818981074801990) started by @oritwoen*