### PR TITLE
feat(hash_collision): add solved() iterator

### DIFF
--- a/src/collections/hash_collision.rs
+++ b/src/collections/hash_collision.rs
@@ -30,7 +30,9 @@ pub fn all() -> impl Iterator<Item = &'static Puzzle> {
 }
 
 pub fn solved() -> impl Iterator<Item = &'static Puzzle> {
-    PUZZLES.iter().filter(|p| p.status == Status::Solved)
+    PUZZLES
+        .iter()
+        .filter(|p| matches!(p.status, Status::Solved | Status::Claimed))
 }
 
 pub fn unsolved() -> impl Iterator<Item = &'static Puzzle> {


### PR DESCRIPTION
Every other multi-puzzle collection (b1000, ballet, bitimage, zden, arweave) exposes both `solved()` and `unsolved()` filters. hash_collision only had `unsolved()`, so filtering solved puzzles across the full dataset required going through `all()` with a manual status check for this one collection.