### PR TITLE
feat: add Chain::address_explorer_url and Puzzle::explorer_url

### DIFF
--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -750,7 +750,12 @@ mod tests {
             (Chain::Arweave, "vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI", "https://viewblock.io/arweave/address/vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI"),
         ];
         for (chain, addr, expected) in cases {
-            assert_eq!(chain.address_explorer_url(addr), *expected, "failed for {:?}", chain);
+            assert_eq!(
+                chain.address_explorer_url(addr),
+                *expected,
+                "failed for {:?}",
+                chain
+            );
         }
     }
 


### PR DESCRIPTION
`tx_explorer_url` gives you a link to a transaction on a block explorer, but there was nothing for addresses. Added `address_explorer_url` on `Chain` and a convenience `explorer_url()` on `Puzzle` that returns the explorer link for the puzzle's address directly.

Covers all six chains with the same explorers already used for transaction URLs.