### PR TITLE
docs: fix README and skill drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ boha range 90
 # Check balance (requires --features balance)
 boha balance b1000/71
 
+# Search puzzles by ID, address, chain, or currency
+boha search sha256
+boha search kitten --collection bitimage
+
 # Verify private key derives correct address
 boha verify b1000/66
 boha verify --all
@@ -103,7 +107,7 @@ boha -o jsonl list b1000 --unsolved | jq .
 ### Library
 
 ```rust
-use boha::{arweave, b1000, ballet, bitaps, gsmg, hash_collision, zden, Status};
+use boha::{arweave, b1000, ballet, bitaps, bitimage, gsmg, hash_collision, warp, zden, Status};
 
 let p90 = b1000::get(90).unwrap();
 println!("Address: {}", p90.address.value);
@@ -124,13 +128,16 @@ let unsolved: Vec<_> = b1000::all()
     .collect();
 
 let gsmg_puzzle = gsmg::get();
+let kitten = bitimage::get("kitten").unwrap();
 let sha256 = hash_collision::get("sha256").unwrap();
+let warp_challenge = warp::get("challenge_1").unwrap();
 let level1 = zden::get("level_1").unwrap();
 
 let puzzle = boha::get("b1000/90").unwrap();
 let puzzle = boha::get("gsmg").unwrap();
 let puzzle = boha::get("bitaps").unwrap();
 let puzzle = boha::get("bitimage/kitten").unwrap();
+let puzzle = boha::get("warp/challenge_1").unwrap();
 let puzzle = boha::get("zden/level_1").unwrap();
 
 // Access puzzle assets (images, hints)
@@ -150,8 +157,8 @@ use boha::{b1000, balance};
 #[tokio::main]
 async fn main() {
     let puzzle = b1000::get(71).unwrap();
-    let bal = balance::fetch(puzzle.address.value).await.unwrap();
-    
+    let bal = balance::fetch(puzzle.address.value, puzzle.chain).await.unwrap();
+
     println!("Confirmed: {} sats", bal.confirmed);
     println!("Total: {:.8} BTC", bal.total_btc());
 }
@@ -162,7 +169,7 @@ async fn main() {
 | Feature | Description |
 |---------|-------------|
 | `cli` | Command-line interface |
-| `balance` | Blockchain balance fetching (mempool.space for BTC/LTC, Etherscan for ETH) |
+| `balance` | Blockchain balance fetching (BTC via mempool.space, LTC via litecoinspace.org, ETH via Etherscan, DCR via dcrdata, AR via arweave.net) |
 
 ## Collections
 
@@ -252,6 +259,17 @@ Two of three required shares are published. Goal: break the SSSS scheme or find 
 | kitten_passphrase | Yes | ⏳ Unsolved | ~0.01 BTC |
 
 Both puzzles use the same source file (Antonopoulos kitten tweet). The passphrase puzzle requires an unknown BIP39 passphrase.
+
+### warp
+
+[Keybase WarpWallet challenges](https://keybase.io/warp) - Brainwallet challenges published to show how quickly weak WarpWallet passphrases get cracked.
+
+| Status | Count |
+|--------|-------|
+| Solved | 4 |
+| Expired | 2 |
+
+Includes the original four November 2013 challenges plus two later WarpWallet-specific challenge rounds reclaimed by Keybase after expiry.
 
 ## Data
 

--- a/skills/boha-cli/SKILL.md
+++ b/skills/boha-cli/SKILL.md
@@ -6,6 +6,8 @@ metadata:
   version: "0.18.0"
 ---
 
+# boha-cli
+
 CLI for browsing crypto bounties, puzzles and challenges. Nine collections across six blockchains. Install with `cargo install boha --features cli,balance` or `paru -S boha` on Arch.
 
 ## Puzzle ID Format

--- a/skills/boha-cli/SKILL.md
+++ b/skills/boha-cli/SKILL.md
@@ -3,10 +3,10 @@ name: boha-cli
 description: Use the boha CLI to browse, search, verify and export crypto puzzle data. Trigger when running boha commands, scripting puzzle lookups, piping puzzle data to other tools, or checking balances from the terminal. Do not use for Rust library integration - see boha skill instead.
 metadata:
   author: oritwoen
-  version: "0.16.0"
+  version: "0.18.0"
 ---
 
-CLI for browsing crypto bounties, puzzles and challenges. Eight collections across six blockchains. Install with `cargo install boha --features cli,balance` or `paru -S boha` on Arch.
+CLI for browsing crypto bounties, puzzles and challenges. Nine collections across six blockchains. Install with `cargo install boha --features cli,balance` or `paru -S boha` on Arch.
 
 ## Puzzle ID Format
 
@@ -21,6 +21,7 @@ IDs follow `collection/identifier` pattern. Two exceptions (`gsmg`, `bitaps`) ha
 | bitimage | `bitimage/kitten` | Name string |
 | gsmg | `gsmg` | Single puzzle, no slash |
 | hash_collision | `hash_collision/sha256` | sha1, sha256, ripemd160, hash160, hash256, op_abs |
+| warp | `warp/challenge_1` | challenge_1-4, warp_challenge_1-2 |
 | zden | `zden/level_1` | snake_case level names |
 
 ## Commands

--- a/skills/boha-cli/references/collections.md
+++ b/skills/boha-cli/references/collections.md
@@ -58,6 +58,15 @@ let p = hash_collision::get("sha256").unwrap();
 let p = boha::get("peter_todd/sha256").unwrap();  // alias works
 ```
 
+## warp
+
+Keybase WarpWallet challenges. 6 puzzles total - 4 solved, 2 expired and later reclaimed by Keybase.
+
+```rust
+let p = warp::get("challenge_1").unwrap();
+let p = boha::get("warp/challenge_1").unwrap();
+```
+
 ## zden
 
 Visual crypto puzzles by Zden. Private keys encoded in images, animations, visual patterns. 15 puzzles across Bitcoin, Ethereum, Litecoin, Decred. 2 unsolved (level_5, level_halv).

--- a/skills/boha/SKILL.md
+++ b/skills/boha/SKILL.md
@@ -3,19 +3,19 @@ name: boha
 description: Use boha as a Rust library for crypto puzzle and bounty data. Trigger when code imports `boha`, references Bitcoin puzzle transactions, hash collision bounties, or needs programmatic access to crypto challenge collections. Do not use for CLI usage - see boha-cli skill instead.
 metadata:
   author: oritwoen
-  version: "0.16.0"
+  version: "0.18.0"
 ---
 
-Rust library for crypto bounties, puzzles and challenges data. Eight collections across six blockchains (Bitcoin, Ethereum, Litecoin, Monero, Decred, Arweave). All data embedded at compile time as `&'static` references.
+Rust library for crypto bounties, puzzles and challenges data. Nine collections across six blockchains (Bitcoin, Ethereum, Litecoin, Monero, Decred, Arweave). All data embedded at compile time as `&'static` references.
 
 ## Install
 
 ```toml
 [dependencies]
-boha = "0.16"
+boha = "0.18"
 
 # With async balance fetching (requires tokio runtime)
-boha = { version = "0.16", features = ["balance"] }
+boha = { version = "0.18", features = ["balance"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -32,6 +32,7 @@ IDs follow `collection/identifier` pattern. Two exceptions have no slash.
 | bitimage | `bitimage/kitten` | Name string |
 | gsmg | `gsmg` | Single puzzle, no slash |
 | hash_collision | `hash_collision/sha256` | sha1, sha256, ripemd160, hash160, hash256, op_abs |
+| warp | `warp/challenge_1` | challenge_1-4, warp_challenge_1-2 |
 | zden | `zden/level_1` | snake_case level names |
 
 ## API
@@ -79,7 +80,7 @@ async fn main() {
 }
 ```
 
-Supports Bitcoin (mempool.space), Litecoin (litecoinspace.org) and Ethereum (Etherscan).
+Supports Bitcoin (mempool.space), Litecoin (litecoinspace.org), Ethereum (Etherscan), Decred (dcrdata) and Arweave (arweave.net).
 
 ## Key Data Types
 

--- a/skills/boha/references/collections.md
+++ b/skills/boha/references/collections.md
@@ -58,6 +58,15 @@ let p = hash_collision::get("sha256").unwrap();
 let p = boha::get("peter_todd/sha256").unwrap();  // alias works
 ```
 
+## warp
+
+Keybase WarpWallet challenges. 6 puzzles total - 4 solved, 2 expired and later reclaimed by Keybase.
+
+```rust
+let p = warp::get("challenge_1").unwrap();
+let p = boha::get("warp/challenge_1").unwrap();
+```
+
 ## zden
 
 Visual crypto puzzles by Zden. Private keys encoded in images, animations, visual patterns. 15 puzzles across Bitcoin, Ethereum, Litecoin, Decred. 2 unsolved (level_5, level_halv).


### PR DESCRIPTION
`README` and bundled skills drifted from current `boha` state. Adds missing `warp` coverage, fixes the stale `balance::fetch(...)` example, and cleans up wrong `warp` ID examples in the skill refs. Small docs-only fix, but dead weight if left around because people copy this stuff.

Closes #150